### PR TITLE
Mayuran/add tabs

### DIFF
--- a/db.json
+++ b/db.json
@@ -16,7 +16,9 @@
         "leader11",
         "leader9",
         "leader2",
-        "leader13"
+        "leader3",
+        "leader8",
+        "leader1"
       ],
       "accounts": [
         "acc1",
@@ -107,7 +109,8 @@
       "userType": "leader",
       "followers": [
         "copier4",
-        "copier5"
+        "copier5",
+        "leader1"
       ],
       "following": [],
       "accounts": [
@@ -194,7 +197,8 @@
       "profilePicture": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d",
       "userType": "leader",
       "followers": [
-        "copier12"
+        "copier12",
+        "leader1"
       ],
       "following": [],
       "accounts": [
@@ -284,8 +288,7 @@
       "userType": "leader",
       "followers": [
         "copier19",
-        "copier20",
-        "leader1"
+        "copier20"
       ],
       "following": [],
       "accounts": [
@@ -460,7 +463,8 @@
       },
       "copiers": [
         "copier1",
-        "copier2"
+        "copier2",
+        "leader1"
       ],
       "isActive": true,
       "createdAt": "2024-01-01T00:00:00Z",
@@ -489,7 +493,7 @@
     {
       "id": "strat3",
       "leaderId": "leader1",
-      "accountId": "acc2",
+      "accountId": "acc7",
       "name": "EUR Scalping",
       "description": "Quick trades on EUR pairs",
       "tradeType": "scalping",
@@ -500,7 +504,8 @@
         "averageProfit": 1.2
       },
       "copiers": [
-        "copier3"
+        "copier3",
+        "leader1"
       ],
       "isActive": true,
       "createdAt": "2024-01-01T00:00:00Z",
@@ -509,7 +514,7 @@
     {
       "id": "strat4",
       "leaderId": "leader2",
-      "accountId": "acc3",
+      "accountId": "acc2",
       "name": "USD Position Trading",
       "description": "Long-term USD position trades",
       "tradeType": "position_trading",
@@ -520,11 +525,224 @@
         "averageProfit": 5.4
       },
       "copiers": [
-        "copier1"
+        "copier1",
+        "leader1"
       ],
       "isActive": true,
       "createdAt": "2024-01-02T00:00:00Z",
       "updatedAt": "2024-01-02T00:00:00Z"
+    },
+    {
+      "id": "strat5",
+      "leaderId": "leader2",
+      "accountId": "acc3",
+      "name": "GBP Trend Following",
+      "description": "Riding long-term trends on GBP pairs",
+      "tradeType": "trend_following",
+      "riskLevel": "medium",
+      "performance": {
+        "totalReturn": 22,
+        "winRate": 65,
+        "averageProfit": 4.5
+      },
+      "copiers": [
+        "copier4",
+        "copier5"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-06T00:00:00Z",
+      "updatedAt": "2024-01-06T00:00:00Z"
+    },
+    {
+      "id": "strat6",
+      "leaderId": "leader3",
+      "accountId": "acc2",
+      "name": "Crypto Momentum",
+      "description": "Capturing short-term momentum in crypto markets",
+      "tradeType": "momentum_trading",
+      "riskLevel": "high",
+      "performance": {
+        "totalReturn": 60,
+        "winRate": 55,
+        "averageProfit": 10
+      },
+      "copiers": [
+        "copier2",
+        "copier3"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-07T00:00:00Z",
+      "updatedAt": "2024-01-07T00:00:00Z"
+    },
+    {
+      "id": "strat7",
+      "leaderId": "leader3",
+      "accountId": "acc3",
+      "name": "ETH Scalping",
+      "description": "Aggressive scalping on ETH pairs",
+      "tradeType": "scalping",
+      "riskLevel": "high",
+      "performance": {
+        "totalReturn": 70,
+        "winRate": 60,
+        "averageProfit": 12
+      },
+      "copiers": [
+        "copier6",
+        "copier7"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-08T00:00:00Z",
+      "updatedAt": "2024-01-08T00:00:00Z"
+    },
+    {
+      "id": "strat8",
+      "leaderId": "leader4",
+      "accountId": "acc4",
+      "name": "AUD Swing Trading",
+      "description": "Swing trading strategy focused on AUD pairs",
+      "tradeType": "swing_trading",
+      "riskLevel": "medium",
+      "performance": {
+        "totalReturn": 25,
+        "winRate": 70,
+        "averageProfit": 3.5
+      },
+      "copiers": [
+        "copier1",
+        "copier8"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-09T00:00:00Z",
+      "updatedAt": "2024-01-09T00:00:00Z"
+    },
+    {
+      "id": "strat9",
+      "leaderId": "leader4",
+      "accountId": "acc1",
+      "name": "NZD Day Trading",
+      "description": "Day trading strategy focusing on NZD pairs",
+      "tradeType": "day_trading",
+      "riskLevel": "medium",
+      "performance": {
+        "totalReturn": 30,
+        "winRate": 65,
+        "averageProfit": 4
+      },
+      "copiers": [
+        "copier2",
+        "copier9"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-10T00:00:00Z",
+      "updatedAt": "2024-01-10T00:00:00Z"
+    },
+    {
+      "id": "strat10",
+      "leaderId": "leader5",
+      "accountId": "acc2",
+      "name": "CAD Position Trading",
+      "description": "Long-term position trading strategy on CAD pairs",
+      "tradeType": "position_trading",
+      "riskLevel": "low",
+      "performance": {
+        "totalReturn": 18,
+        "winRate": 78,
+        "averageProfit": 2.8
+      },
+      "copiers": [
+        "copier3",
+        "copier10"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-11T00:00:00Z",
+      "updatedAt": "2024-01-11T00:00:00Z"
+    },
+    {
+      "id": "strat11",
+      "leaderId": "leader5",
+      "accountId": "acc2",
+      "name": "JPY Trend Following",
+      "description": "Riding long-term trends on JPY pairs",
+      "tradeType": "trend_following",
+      "riskLevel": "medium",
+      "performance": {
+        "totalReturn": 27,
+        "winRate": 67,
+        "averageProfit": 4.2
+      },
+      "copiers": [
+        "copier4",
+        "copier5",
+        "leader1"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-12T00:00:00Z",
+      "updatedAt": "2024-01-12T00:00:00Z"
+    },
+    {
+      "id": "strat12",
+      "leaderId": "leader6",
+      "accountId": "acc3",
+      "name": "CHF Swing Trading",
+      "description": "Swing trading strategy focused on CHF pairs",
+      "tradeType": "swing_trading",
+      "riskLevel": "low",
+      "performance": {
+        "totalReturn": 16.5,
+        "winRate": 76,
+        "averageProfit": 2.5
+      },
+      "copiers": [
+        "copier6",
+        "copier7"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-13T00:00:00Z",
+      "updatedAt": "2024-01-13T00:00:00Z"
+    },
+    {
+      "id": "strat13",
+      "leaderId": "leader6",
+      "accountId": "acc3",
+      "name": "XAUUSD Scalping",
+      "description": "Scalping strategy focused on Gold",
+      "tradeType": "scalping",
+      "riskLevel": "high",
+      "performance": {
+        "totalReturn": 55,
+        "winRate": 58,
+        "averageProfit": 9
+      },
+      "copiers": [
+        "copier8",
+        "copier9",
+        "leader1"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-14T00:00:00Z",
+      "updatedAt": "2024-01-14T00:00:00Z"
+    },
+    {
+      "id": "strat14",
+      "leaderId": "leader7",
+      "accountId": "acc4",
+      "name": "Crude Oil Momentum",
+      "description": "Momentum Trading strategy focused on Crude Oil",
+      "tradeType": "momentum_trading",
+      "riskLevel": "high",
+      "performance": {
+        "totalReturn": 48,
+        "winRate": 57,
+        "averageProfit": 8
+      },
+      "copiers": [
+        "copier10",
+        "copier1"
+      ],
+      "isActive": true,
+      "createdAt": "2024-01-15T00:00:00Z",
+      "updatedAt": "2024-01-15T00:00:00Z"
     }
   ],
   "copyRelationships": [
@@ -582,6 +800,281 @@
       "copySize": 1000,
       "createdAt": "2024-01-03T00:00:00Z",
       "updatedAt": "2024-01-03T00:00:00Z"
+    },
+    {
+      "id": "copy6",
+      "copierId": "copier4",
+      "leaderId": "leader2",
+      "strategyId": "strat5",
+      "copierAccountId": "acc9",
+      "status": "active",
+      "copySize": 1500,
+      "createdAt": "2024-01-08T00:00:00Z",
+      "updatedAt": "2024-01-08T00:00:00Z"
+    },
+    {
+      "id": "copy7",
+      "copierId": "copier5",
+      "leaderId": "leader2",
+      "strategyId": "strat5",
+      "copierAccountId": "acc10",
+      "status": "active",
+      "copySize": 800,
+      "createdAt": "2024-01-09T00:00:00Z",
+      "updatedAt": "2024-01-09T00:00:00Z"
+    },
+    {
+      "id": "copy8",
+      "copierId": "copier2",
+      "leaderId": "leader3",
+      "strategyId": "strat6",
+      "copierAccountId": "acc5",
+      "status": "active",
+      "copySize": 1200,
+      "createdAt": "2024-01-10T00:00:00Z",
+      "updatedAt": "2024-01-10T00:00:00Z"
+    },
+    {
+      "id": "copy9",
+      "copierId": "copier3",
+      "leaderId": "leader3",
+      "strategyId": "strat6",
+      "copierAccountId": "acc6",
+      "status": "active",
+      "copySize": 3000,
+      "createdAt": "2024-01-11T00:00:00Z",
+      "updatedAt": "2024-01-11T00:00:00Z"
+    },
+    {
+      "id": "copy10",
+      "copierId": "copier6",
+      "leaderId": "leader3",
+      "strategyId": "strat7",
+      "copierAccountId": "acc15",
+      "status": "active",
+      "copySize": 900,
+      "createdAt": "2024-01-12T00:00:00Z",
+      "updatedAt": "2024-01-12T00:00:00Z"
+    },
+    {
+      "id": "copy11",
+      "copierId": "copier7",
+      "leaderId": "leader3",
+      "strategyId": "strat7",
+      "copierAccountId": "acc16",
+      "status": "active",
+      "copySize": 1100,
+      "createdAt": "2024-01-13T00:00:00Z",
+      "updatedAt": "2024-01-13T00:00:00Z"
+    },
+    {
+      "id": "copy12",
+      "copierId": "copier1",
+      "leaderId": "leader4",
+      "strategyId": "strat8",
+      "copierAccountId": "acc4",
+      "status": "active",
+      "copySize": 700,
+      "createdAt": "2024-01-14T00:00:00Z",
+      "updatedAt": "2024-01-14T00:00:00Z"
+    },
+    {
+      "id": "copy13",
+      "copierId": "copier8",
+      "leaderId": "leader4",
+      "strategyId": "strat8",
+      "copierAccountId": "acc17",
+      "status": "active",
+      "copySize": 1300,
+      "createdAt": "2024-01-15T00:00:00Z",
+      "updatedAt": "2024-01-15T00:00:00Z"
+    },
+    {
+      "id": "copy14",
+      "copierId": "copier2",
+      "leaderId": "leader4",
+      "strategyId": "strat9",
+      "copierAccountId": "acc5",
+      "status": "active",
+      "copySize": 1000,
+      "createdAt": "2024-01-16T00:00:00Z",
+      "updatedAt": "2024-01-16T00:00:00Z"
+    },
+    {
+      "id": "copy15",
+      "copierId": "copier9",
+      "leaderId": "leader4",
+      "strategyId": "strat9",
+      "copierAccountId": "acc18",
+      "status": "active",
+      "copySize": 1600,
+      "createdAt": "2024-01-17T00:00:00Z",
+      "updatedAt": "2024-01-17T00:00:00Z"
+    },
+    {
+      "id": "copy16",
+      "copierId": "copier3",
+      "leaderId": "leader5",
+      "strategyId": "strat10",
+      "copierAccountId": "acc6",
+      "status": "active",
+      "copySize": 1400,
+      "createdAt": "2024-01-18T00:00:00Z",
+      "updatedAt": "2024-01-18T00:00:00Z"
+    },
+    {
+      "id": "copy17",
+      "copierId": "copier10",
+      "leaderId": "leader5",
+      "strategyId": "strat10",
+      "copierAccountId": "acc19",
+      "status": "active",
+      "copySize": 1700,
+      "createdAt": "2024-01-19T00:00:00Z",
+      "updatedAt": "2024-01-19T00:00:00Z"
+    },
+    {
+      "id": "copy18",
+      "copierId": "copier4",
+      "leaderId": "leader5",
+      "strategyId": "strat11",
+      "copierAccountId": "acc9",
+      "status": "active",
+      "copySize": 1100,
+      "createdAt": "2024-01-20T00:00:00Z",
+      "updatedAt": "2024-01-20T00:00:00Z"
+    },
+    {
+      "id": "copy19",
+      "copierId": "copier5",
+      "leaderId": "leader5",
+      "strategyId": "strat11",
+      "copierAccountId": "acc10",
+      "status": "active",
+      "copySize": 900,
+      "createdAt": "2024-01-21T00:00:00Z",
+      "updatedAt": "2024-01-21T00:00:00Z"
+    },
+    {
+      "id": "copy20",
+      "copierId": "copier6",
+      "leaderId": "leader6",
+      "strategyId": "strat12",
+      "copierAccountId": "acc15",
+      "status": "active",
+      "copySize": 1200,
+      "createdAt": "2024-01-22T00:00:00Z",
+      "updatedAt": "2024-01-22T00:00:00Z"
+    },
+    {
+      "id": "copy21",
+      "copierId": "copier7",
+      "leaderId": "leader6",
+      "strategyId": "strat12",
+      "copierAccountId": "acc16",
+      "status": "active",
+      "copySize": 1500,
+      "createdAt": "2024-01-23T00:00:00Z",
+      "updatedAt": "2024-01-23T00:00:00Z"
+    },
+    {
+      "id": "copy22",
+      "copierId": "copier8",
+      "leaderId": "leader6",
+      "strategyId": "strat13",
+      "copierAccountId": "acc17",
+      "status": "active",
+      "copySize": 800,
+      "createdAt": "2024-01-24T00:00:00Z",
+      "updatedAt": "2024-01-24T00:00:00Z"
+    },
+    {
+      "id": "copy23",
+      "copierId": "copier9",
+      "leaderId": "leader6",
+      "strategyId": "strat13",
+      "copierAccountId": "acc18",
+      "status": "active",
+      "copySize": 1100,
+      "createdAt": "2024-01-25T00:00:00Z",
+      "updatedAt": "2024-01-25T00:00:00Z"
+    },
+    {
+      "id": "copy24",
+      "copierId": "copier10",
+      "leaderId": "leader7",
+      "strategyId": "strat14",
+      "copierAccountId": "acc19",
+      "status": "active",
+      "copySize": 1300,
+      "createdAt": "2024-01-26T00:00:00Z",
+      "updatedAt": "2024-01-26T00:00:00Z"
+    },
+    {
+      "id": "copy25",
+      "copierId": "copier1",
+      "leaderId": "leader7",
+      "strategyId": "strat14",
+      "copierAccountId": "acc4",
+      "status": "active",
+      "copySize": 900,
+      "createdAt": "2024-01-27T00:00:00Z",
+      "updatedAt": "2024-01-27T00:00:00Z"
+    },
+    {
+      "id": "leader1-strat11",
+      "copierId": "leader1",
+      "leaderId": "leader5",
+      "strategyId": "strat11",
+      "copierAccountId": "default",
+      "status": "active",
+      "copySize": 1000,
+      "createdAt": "2025-02-13T12:09:39.722Z",
+      "updatedAt": "2025-02-13T12:09:39.722Z"
+    },
+    {
+      "id": "leader1-strat13",
+      "copierId": "leader1",
+      "leaderId": "leader6",
+      "strategyId": "strat13",
+      "copierAccountId": "default",
+      "status": "active",
+      "copySize": 1000,
+      "createdAt": "2025-02-13T12:15:13.131Z",
+      "updatedAt": "2025-02-13T12:15:13.131Z"
+    },
+    {
+      "id": "leader1-strat4",
+      "copierId": "leader1",
+      "leaderId": "leader2",
+      "strategyId": "strat4",
+      "copierAccountId": "default",
+      "status": "active",
+      "copySize": 1000,
+      "createdAt": "2025-02-13T13:25:24.482Z",
+      "updatedAt": "2025-02-13T13:25:24.482Z"
+    },
+    {
+      "id": "leader1-strat1",
+      "copierId": "leader1",
+      "leaderId": "leader1",
+      "strategyId": "strat1",
+      "copierAccountId": "default",
+      "status": "active",
+      "copySize": 1000,
+      "createdAt": "2025-02-13T13:25:27.472Z",
+      "updatedAt": "2025-02-13T13:25:27.472Z"
+    },
+    {
+      "id": "leader1-strat3",
+      "copierId": "leader1",
+      "leaderId": "leader1",
+      "strategyId": "strat3",
+      "copierAccountId": "default",
+      "status": "active",
+      "copySize": 1000,
+      "createdAt": "2025-02-13T13:25:31.810Z",
+      "updatedAt": "2025-02-13T13:25:31.810Z"
     }
   ],
   "posts": [

--- a/db.json
+++ b/db.json
@@ -14,12 +14,14 @@
         "leader1"
       ],
       "following": [
-        "leader11",
         "leader9",
-        "leader2",
         "leader3",
         "leader8",
-        "leader1"
+        "leader1",
+        "leader4",
+        "leader5",
+        "leader11",
+        "leader6"
       ],
       "accounts": [
         "acc1",
@@ -44,7 +46,6 @@
       "followers": [
         "copier1",
         "copier3",
-        "leader1",
         "leader2"
       ],
       "following": [
@@ -146,7 +147,8 @@
       "profilePicture": "https://images.unsplash.com/photo-1519085360753-af0119f7cbe7",
       "userType": "leader",
       "followers": [
-        "copier6"
+        "copier6",
+        "leader1"
       ],
       "following": [],
       "accounts": [
@@ -164,7 +166,8 @@
       "userType": "leader",
       "followers": [
         "copier7",
-        "copier8"
+        "copier8",
+        "leader1"
       ],
       "following": [],
       "accounts": [
@@ -181,7 +184,8 @@
       "profilePicture": "https://images.unsplash.com/photo-1506794778202-cad84cf45f1d",
       "userType": "leader",
       "followers": [
-        "copier9"
+        "copier9",
+        "leader1"
       ],
       "following": [],
       "accounts": [
@@ -482,8 +486,7 @@
       },
       "copiers": [
         "copier1",
-        "copier2",
-        "leader1"
+        "copier2"
       ],
       "isActive": true,
       "createdAt": "2024-01-01T00:00:00Z",
@@ -692,8 +695,7 @@
       },
       "copiers": [
         "copier4",
-        "copier5",
-        "leader1"
+        "copier5"
       ],
       "isActive": true,
       "createdAt": "2024-01-12T00:00:00Z",
@@ -735,8 +737,7 @@
       },
       "copiers": [
         "copier8",
-        "copier9",
-        "leader1"
+        "copier9"
       ],
       "isActive": true,
       "createdAt": "2024-01-14T00:00:00Z",
@@ -1041,28 +1042,6 @@
       "updatedAt": "2024-01-27T00:00:00Z"
     },
     {
-      "id": "leader1-strat11",
-      "copierId": "leader1",
-      "leaderId": "leader5",
-      "strategyId": "strat11",
-      "copierAccountId": "default",
-      "status": "active",
-      "copySize": 1000,
-      "createdAt": "2025-02-13T12:09:39.722Z",
-      "updatedAt": "2025-02-13T12:09:39.722Z"
-    },
-    {
-      "id": "leader1-strat13",
-      "copierId": "leader1",
-      "leaderId": "leader6",
-      "strategyId": "strat13",
-      "copierAccountId": "default",
-      "status": "active",
-      "copySize": 1000,
-      "createdAt": "2025-02-13T12:15:13.131Z",
-      "updatedAt": "2025-02-13T12:15:13.131Z"
-    },
-    {
       "id": "leader1-strat4",
       "copierId": "leader1",
       "leaderId": "leader2",
@@ -1074,17 +1053,6 @@
       "updatedAt": "2025-02-13T13:25:24.482Z"
     },
     {
-      "id": "leader1-strat1",
-      "copierId": "leader1",
-      "leaderId": "leader1",
-      "strategyId": "strat1",
-      "copierAccountId": "default",
-      "status": "active",
-      "copySize": 1000,
-      "createdAt": "2025-02-13T13:25:27.472Z",
-      "updatedAt": "2025-02-13T13:25:27.472Z"
-    },
-    {
       "id": "leader1-strat3",
       "copierId": "leader1",
       "leaderId": "leader1",
@@ -1092,8 +1060,8 @@
       "copierAccountId": "default",
       "status": "active",
       "copySize": 1000,
-      "createdAt": "2025-02-13T13:25:31.810Z",
-      "updatedAt": "2025-02-13T13:25:31.810Z"
+      "createdAt": "2025-02-13T14:17:59.717Z",
+      "updatedAt": "2025-02-13T14:17:59.717Z"
     }
   ],
   "posts": [

--- a/src/components/navigation/TabNavigation/TabNavigation.css
+++ b/src/components/navigation/TabNavigation/TabNavigation.css
@@ -1,45 +1,45 @@
 .tab-navigation {
-    height: 56px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0 16px;
-    z-index: 1000;
+  height: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 16px;
+  z-index: 1000;
 }
 
 .tab-container {
-    display: flex;
-    gap: 24px;
+  display: flex;
+  gap: 24px;
 }
 
 .tab {
-    background: none;
-    border: none;
-    color: black;
-    font-size: 16px;
-    font-weight: 600;
-    padding: 8px 0;
-    position: relative;
-    cursor: pointer;
-    transition: all 0.2s ease;
+  background: none;
+  border: none;
+  color: black;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 8px 0;
+  position: relative;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
 .tab::after {
-    content: '';
-    position: absolute;
-    bottom: -2px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: black;
-    transform: scaleX(0);
-    transition: transform 0.2s ease;
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: black;
+  transform: scaleX(0);
+  transition: transform 0.2s ease;
 }
 
 .tab.active {
-    color: black;
+  color: black;
 }
 
 .tab.active::after {
-    transform: scaleX(1);
+  transform: scaleX(1);
 }

--- a/src/pages/discover/Discover.css
+++ b/src/pages/discover/Discover.css
@@ -4,8 +4,27 @@
 
 .discover__title {
   font-size: 2rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   color: var(--text-primary);
+  text-align: center;
+}
+
+.discover .tab-navigation {
+  margin: 0 auto 2rem;
+  max-width: 400px;
+  padding: 0 1rem;
+}
+
+.discover__strategies {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+
+.discover__empty-message {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
   text-align: center;
 }
 

--- a/src/pages/discover/Discover.tsx
+++ b/src/pages/discover/Discover.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { useAuth } from "../../context/AuthContext";
+import { CopyRelationship } from "../../types/copy.types";
 import AiGif from "../../assets/icons/ai.gif";
 import SkeletonCard from "./components/SkeletonCard";
 import LeaderCard from "./components/LeaderCard";
+import StrategyCard from "./components/StrategyCard";
+import TabNavigation from "../../components/navigation/TabNavigation";
 import "./Discover.css";
 
-type Leader = {
+interface Leader {
   id: string;
   username: string;
   avatar?: string;
@@ -13,20 +16,155 @@ type Leader = {
   totalProfit: number;
   winRate: number;
   isFollowing: boolean;
-};
+}
 
-type User = {
+interface User {
   id: string;
   username: string;
+  displayName: string;
   profilePicture?: string;
   userType: string;
-};
+  following: string[];
+  followers: string[];
+}
+
+interface CurrencyAccount {
+  id: string;
+  userId: string;
+  currency: string;
+  balance: number;
+  tradingStrategies: string[];
+  isActive: boolean;
+}
+
+interface TradingStrategy {
+  id: string;
+  leaderId: string;
+  accountId: string;
+  name: string;
+  description: string;
+  tradeType: string;
+  riskLevel: string;
+  copiers: string[];
+  isActive: boolean;
+}
+
+interface Strategy {
+  id: string;
+  leaderId: string;
+  accountId: string;
+  name: string;
+  description: string;
+  tradeType: string;
+  copiers: string[];
+  leader?: {
+    username: string;
+    displayName: string;
+    profilePicture?: string;
+  };
+  currency?: string;
+  isFollowing?: boolean;
+  isCopying?: boolean;
+}
 
 export default function Discover() {
+  const [activeTab, setActiveTab] = useState("Leaders");
   const [leaders, setLeaders] = useState<Leader[]>([]);
+  const [strategies, setStrategies] = useState<Strategy[]>([]);
   const [loading, setLoading] = useState(true);
 
   const { user } = useAuth();
+
+  const tabs = ["Leaders", "Strategies"];
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+  };
+
+  const handleCopyStrategy = useCallback(
+    async (strategyId: string) => {
+      if (!user) return;
+
+      try {
+        // Get current strategy data
+        const strategyRes = await fetch(
+          `http://localhost:3001/tradingStrategies/${strategyId}`
+        );
+        const strategy = await strategyRes.json();
+
+        // Check if relationship already exists
+        const relationshipId = `${user.id}-${strategyId}`;
+        const existingRes = await fetch(
+          `http://localhost:3001/copyRelationships?id=${relationshipId}`
+        );
+        const existing = await existingRes.json();
+
+        if (existing.length > 0) {
+          // Delete existing relationship
+          await fetch(
+            `http://localhost:3001/copyRelationships/${relationshipId}`,
+            {
+              method: "DELETE",
+            }
+          );
+
+          // Remove user from strategy copiers
+          strategy.copiers = strategy.copiers.filter(
+            (id: string) => id !== user.id
+          );
+          await fetch(`http://localhost:3001/tradingStrategies/${strategyId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(strategy),
+          });
+
+          // Update local state to show "Copy Strategy"
+          setStrategies((prevStrategies) =>
+            prevStrategies.map((s) =>
+              s.id === strategyId ? { ...s, isCopying: false } : s
+            )
+          );
+        } else {
+          // Create new copy relationship
+          const copyRelationship = {
+            id: relationshipId,
+            copierId: user.id,
+            leaderId: strategy.leaderId,
+            strategyId: strategyId,
+            copierAccountId: "default", // You might want to let user select an account
+            status: "active",
+            copySize: 1000, // Default copy size
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+
+          await fetch("http://localhost:3001/copyRelationships", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(copyRelationship),
+          });
+
+          // Add user to strategy copiers
+          strategy.copiers.push(user.id);
+          await fetch(`http://localhost:3001/tradingStrategies/${strategyId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(strategy),
+          });
+
+          // Update local state to show "Stop Copying"
+          setStrategies((prevStrategies) =>
+            prevStrategies.map((s) =>
+              s.id === strategyId ? { ...s, isCopying: true } : s
+            )
+          );
+        }
+      } catch (error) {
+        console.error("Error copying strategy:", error);
+      }
+    },
+    [user]
+  );
 
   const handleFollowToggle = useCallback(
     async (leaderId: string) => {
@@ -72,12 +210,19 @@ export default function Discover() {
           }),
         ]);
 
-        // Update local state
-        setLeaders((prevLeaders: Leader[]) =>
-          prevLeaders.map((leader: Leader) =>
+        // Update local state for both leaders and strategies
+        setLeaders((prevLeaders) =>
+          prevLeaders.map((leader) =>
             leader.id === leaderId
               ? { ...leader, isFollowing: !leader.isFollowing }
               : leader
+          )
+        );
+        setStrategies((prevStrategies) =>
+          prevStrategies.map((strategy) =>
+            strategy.leaderId === leaderId
+              ? { ...strategy, isFollowing: !strategy.isFollowing }
+              : strategy
           )
         );
       } catch (error) {
@@ -87,73 +232,129 @@ export default function Discover() {
     [user]
   );
 
-  // Top 3 leaders sorted by profit
+  // Memoized sections
   const topLeaders = useMemo(() => {
     return [...leaders]
       .sort((a, b) => b.totalProfit - a.totalProfit)
       .slice(0, 3);
   }, [leaders]);
 
-  // AI Suggested Leaders (random selection)
   const aiSuggestedLeaders = useMemo(() => {
     return [...leaders].sort(() => Math.random() - 0.5).slice(0, 5);
   }, [leaders]);
 
-  // Top Earners (random selection)
   const topEarners = useMemo(() => {
     return [...leaders].sort(() => Math.random() - 0.5).slice(0, 5);
   }, [leaders]);
 
-  // Most Popular (random selection)
   const mostPopular = useMemo(() => {
     return [...leaders].sort(() => Math.random() - 0.5).slice(0, 5);
   }, [leaders]);
 
+  // Strategy sections
+  const topStrategies = useMemo(() => {
+    return [...strategies]
+      .sort((a, b) => b.copiers.length - a.copiers.length)
+      .slice(0, 3);
+  }, [strategies]);
+
+  const aiSuggestedStrategies = useMemo(() => {
+    return [...strategies].sort(() => Math.random() - 0.5).slice(0, 5);
+  }, [strategies]);
+
+  const popularStrategies = useMemo(() => {
+    return [...strategies].sort(() => Math.random() - 0.5).slice(0, 5);
+  }, [strategies]);
+
   useEffect(() => {
-    const fetchLeaders = async () => {
+    const fetchData = async () => {
       try {
-        const res = await fetch("http://localhost:3001/users");
-        const users: User[] = await res.json();
-        console.log(users);
+        setLoading(true);
+        const [usersRes, strategiesRes, currencyAccountsRes] =
+          await Promise.all([
+            fetch("http://localhost:3001/users"),
+            fetch("http://localhost:3001/tradingStrategies"),
+            fetch("http://localhost:3001/currencyAccounts"),
+          ]);
 
-        // Get leaders with random stats
+        const [users, strategiesData, accounts]: [
+          User[],
+          TradingStrategy[],
+          CurrencyAccount[]
+        ] = await Promise.all([
+          usersRes.json(),
+          strategiesRes.json(),
+          currencyAccountsRes.json(),
+        ]);
+
         // Get current user data to check following status
-        const currentUserRes = user
-          ? await fetch(`http://localhost:3001/users/${user.id}`)
-          : null;
-        const currentUserData = currentUserRes
-          ? await currentUserRes.json()
+        const currentUserData = user
+          ? await fetch(`http://localhost:3001/users/${user.id}`).then((res) =>
+              res.json()
+            )
           : null;
 
+        // Process leaders
         const leaders = users
           .filter((u) => u.userType === "leader")
           .map((leader) => ({
             id: leader.id,
             username: leader.username,
             avatar: leader.profilePicture,
-            copiers: Math.floor(Math.random() * 2000) + 500, // Random copiers between 500-2500
-            totalProfit: Math.floor(Math.random() * 900000) + 100000, // Random profit between 100k-1M
-            winRate: Math.floor(Math.random() * 20) + 70, // Random win rate between 70-90%
+            copiers: Math.floor(Math.random() * 2000) + 500,
+            totalProfit: Math.floor(Math.random() * 900000) + 100000,
+            winRate: Math.floor(Math.random() * 20) + 70,
             isFollowing: currentUserData
               ? currentUserData.following.includes(leader.id)
               : false,
-          }))
-          .sort((a, b) => b.totalProfit - a.totalProfit);
+          }));
+
+        // Process strategies
+        // Get copy relationships for current user
+        const copyRelationsRes = await fetch(
+          `http://localhost:3001/copyRelationships?copierId=${user?.id}`
+        );
+        const copyRelations = await copyRelationsRes.json();
+
+        const processedStrategies = strategiesData.map((strategy) => {
+          const leader = users.find((u) => u.id === strategy.leaderId);
+          const account = accounts.find((a) => a.id === strategy.accountId);
+          console.log(account, "strategy", accounts, strategy.accountId);
+          const isCopying = copyRelations.some(
+            (rel: CopyRelationship) => rel.strategyId === strategy.id
+          );
+          return {
+            ...strategy,
+            leader: leader
+              ? {
+                  username: leader.username,
+                  displayName: leader.displayName,
+                  profilePicture: leader.profilePicture,
+                }
+              : undefined,
+            currency: account?.currency,
+            isFollowing: currentUserData
+              ? currentUserData.following.includes(strategy.leaderId)
+              : false,
+            isCopying,
+          };
+        });
 
         setLeaders(leaders);
+        setStrategies(processedStrategies);
         setLoading(false);
       } catch (error) {
-        console.error("Error fetching leaders:", error);
+        console.error("Error fetching data:", error);
         setLoading(false);
       }
     };
 
-    fetchLeaders();
-  }, []);
+    fetchData();
+  }, [user]);
 
   return (
     <div className="discover">
-      <h1 className="discover__title">Top Leaders</h1>
+      <h1 className="discover__title">Discover</h1>
       <div className="discover__search">
         <input
           type="search"
@@ -164,34 +365,108 @@ export default function Discover() {
           <img src={AiGif} alt="AI Search" />
         </button>
       </div>
-      {loading ? (
+      <TabNavigation
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+      />
+      {activeTab === "Leaders" ? (
+        loading ? (
+          <>
+            <h2 className="discover__section-title">Top 3 Leaders</h2>
+            <div className="discover__top-leaders">
+              {[...Array(3)].map((_, index) => (
+                <SkeletonCard key={index} large showRank />
+              ))}
+            </div>
+
+            <h2 className="discover__section-title">AI Suggested Leaders</h2>
+            <div className="discover__leaders-grid">
+              {[...Array(5)].map((_, index) => (
+                <SkeletonCard key={`ai-${index}`} />
+              ))}
+            </div>
+
+            <h2 className="discover__section-title">Top Earners</h2>
+            <div className="discover__leaders-grid">
+              {[...Array(5)].map((_, index) => (
+                <SkeletonCard key={`earners-${index}`} />
+              ))}
+            </div>
+
+            <h2 className="discover__section-title">Most Popular</h2>
+            <div className="discover__leaders-grid">
+              {[...Array(5)].map((_, index) => (
+                <SkeletonCard key={`popular-${index}`} />
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="discover__section-title">Top 3 Leaders</h2>
+            <div className="discover__top-leaders">
+              {topLeaders.map((leader, index) => (
+                <LeaderCard
+                  key={leader.id}
+                  leader={leader}
+                  rank={index + 1}
+                  onFollow={handleFollowToggle}
+                  large
+                />
+              ))}
+            </div>
+
+            <h2 className="discover__section-title">AI Suggested Leaders</h2>
+            <div className="discover__leaders-grid">
+              {aiSuggestedLeaders.map((leader) => (
+                <LeaderCard
+                  key={leader.id}
+                  leader={leader}
+                  onFollow={handleFollowToggle}
+                />
+              ))}
+            </div>
+
+            <h2 className="discover__section-title">Top Earners</h2>
+            <div className="discover__leaders-grid">
+              {topEarners.map((leader) => (
+                <LeaderCard
+                  key={leader.id}
+                  leader={leader}
+                  onFollow={handleFollowToggle}
+                />
+              ))}
+            </div>
+
+            <h2 className="discover__section-title">Most Popular</h2>
+            <div className="discover__leaders-grid">
+              {mostPopular.map((leader) => (
+                <LeaderCard
+                  key={leader.id}
+                  leader={leader}
+                  onFollow={handleFollowToggle}
+                />
+              ))}
+            </div>
+          </>
+        )
+      ) : loading ? (
         <>
-          {/* Top 3 Leaders */}
-          <h2 className="discover__section-title">Top 3 Leaders</h2>
+          <h2 className="discover__section-title">Top Strategies</h2>
           <div className="discover__top-leaders">
             {[...Array(3)].map((_, index) => (
               <SkeletonCard key={index} large showRank />
             ))}
           </div>
 
-          {/* AI Suggested Leaders */}
-          <h2 className="discover__section-title">AI Suggested Leaders</h2>
+          <h2 className="discover__section-title">AI Suggested Strategies</h2>
           <div className="discover__leaders-grid">
             {[...Array(5)].map((_, index) => (
               <SkeletonCard key={`ai-${index}`} />
             ))}
           </div>
 
-          {/* Top Earners */}
-          <h2 className="discover__section-title">Top Earners</h2>
-          <div className="discover__leaders-grid">
-            {[...Array(5)].map((_, index) => (
-              <SkeletonCard key={`earners-${index}`} />
-            ))}
-          </div>
-
-          {/* Most Popular */}
-          <h2 className="discover__section-title">Most Popular</h2>
+          <h2 className="discover__section-title">Popular Strategies</h2>
           <div className="discover__leaders-grid">
             {[...Array(5)].map((_, index) => (
               <SkeletonCard key={`popular-${index}`} />
@@ -200,52 +475,40 @@ export default function Discover() {
         </>
       ) : (
         <>
-          {/* Top 3 Leaders */}
-          <h2 className="discover__section-title">Top 3 Leaders</h2>
+          <h2 className="discover__section-title">Top Strategies</h2>
           <div className="discover__top-leaders">
-            {topLeaders.map((leader, index) => (
-              <LeaderCard
-                key={leader.id}
-                leader={leader}
+            {topStrategies.map((strategy, index) => (
+              <StrategyCard
+                key={strategy.id}
+                strategy={strategy}
                 rank={index + 1}
                 onFollow={handleFollowToggle}
+                onCopy={handleCopyStrategy}
                 large
               />
             ))}
           </div>
 
-          {/* AI Suggested Leaders */}
-          <h2 className="discover__section-title">AI Suggested Leaders</h2>
+          <h2 className="discover__section-title">AI Suggested Strategies</h2>
           <div className="discover__leaders-grid">
-            {aiSuggestedLeaders.map((leader) => (
-              <LeaderCard
-                key={leader.id}
-                leader={leader}
+            {aiSuggestedStrategies.map((strategy) => (
+              <StrategyCard
+                key={strategy.id}
+                strategy={strategy}
                 onFollow={handleFollowToggle}
+                onCopy={handleCopyStrategy}
               />
             ))}
           </div>
 
-          {/* Top Earners */}
-          <h2 className="discover__section-title">Top Earners</h2>
+          <h2 className="discover__section-title">Popular Strategies</h2>
           <div className="discover__leaders-grid">
-            {topEarners.map((leader) => (
-              <LeaderCard
-                key={leader.id}
-                leader={leader}
+            {popularStrategies.map((strategy) => (
+              <StrategyCard
+                key={strategy.id}
+                strategy={strategy}
                 onFollow={handleFollowToggle}
-              />
-            ))}
-          </div>
-
-          {/* Most Popular */}
-          <h2 className="discover__section-title">Most Popular</h2>
-          <div className="discover__leaders-grid">
-            {mostPopular.map((leader) => (
-              <LeaderCard
-                key={leader.id}
-                leader={leader}
-                onFollow={handleFollowToggle}
+                onCopy={handleCopyStrategy}
               />
             ))}
           </div>

--- a/src/pages/discover/Discover.tsx
+++ b/src/pages/discover/Discover.tsx
@@ -1,21 +1,31 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useAuth } from "../../context/AuthContext";
 import { CopyRelationship } from "../../types/copy.types";
-import AiGif from "../../assets/icons/ai.gif";
-import SkeletonCard from "./components/SkeletonCard";
-import LeaderCard from "./components/LeaderCard";
-import StrategyCard from "./components/StrategyCard";
 import TabNavigation from "../../components/navigation/TabNavigation";
+import Search from "./components/Search";
+import LeadersSection from "./components/LeadersSection";
+import StrategiesSection from "./components/StrategiesSection";
 import "./Discover.css";
 
-interface Leader {
+interface TradingStrategy {
   id: string;
-  username: string;
-  avatar?: string;
-  copiers: number;
-  totalProfit: number;
-  winRate: number;
-  isFollowing: boolean;
+  leaderId: string;
+  accountId: string;
+  name: string;
+  description: string;
+  tradeType: string;
+  riskLevel: string;
+  copiers: string[];
+  isActive: boolean;
+}
+
+interface CurrencyAccount {
+  id: string;
+  userId: string;
+  currency: string;
+  balance: number;
+  tradingStrategies: string[];
+  isActive: boolean;
 }
 
 interface User {
@@ -28,25 +38,14 @@ interface User {
   followers: string[];
 }
 
-interface CurrencyAccount {
+interface Leader {
   id: string;
-  userId: string;
-  currency: string;
-  balance: number;
-  tradingStrategies: string[];
-  isActive: boolean;
-}
-
-interface TradingStrategy {
-  id: string;
-  leaderId: string;
-  accountId: string;
-  name: string;
-  description: string;
-  tradeType: string;
-  riskLevel: string;
-  copiers: string[];
-  isActive: boolean;
+  username: string;
+  avatar?: string;
+  copiers: number;
+  totalProfit: number;
+  winRate: number;
+  isFollowing: boolean;
 }
 
 interface Strategy {
@@ -232,40 +231,6 @@ export default function Discover() {
     [user]
   );
 
-  // Memoized sections
-  const topLeaders = useMemo(() => {
-    return [...leaders]
-      .sort((a, b) => b.totalProfit - a.totalProfit)
-      .slice(0, 3);
-  }, [leaders]);
-
-  const aiSuggestedLeaders = useMemo(() => {
-    return [...leaders].sort(() => Math.random() - 0.5).slice(0, 5);
-  }, [leaders]);
-
-  const topEarners = useMemo(() => {
-    return [...leaders].sort(() => Math.random() - 0.5).slice(0, 5);
-  }, [leaders]);
-
-  const mostPopular = useMemo(() => {
-    return [...leaders].sort(() => Math.random() - 0.5).slice(0, 5);
-  }, [leaders]);
-
-  // Strategy sections
-  const topStrategies = useMemo(() => {
-    return [...strategies]
-      .sort((a, b) => b.copiers.length - a.copiers.length)
-      .slice(0, 3);
-  }, [strategies]);
-
-  const aiSuggestedStrategies = useMemo(() => {
-    return [...strategies].sort(() => Math.random() - 0.5).slice(0, 5);
-  }, [strategies]);
-
-  const popularStrategies = useMemo(() => {
-    return [...strategies].sort(() => Math.random() - 0.5).slice(0, 5);
-  }, [strategies]);
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -355,164 +320,25 @@ export default function Discover() {
   return (
     <div className="discover">
       <h1 className="discover__title">Discover</h1>
-      <div className="discover__search">
-        <input
-          type="search"
-          className="discover__search-input"
-          placeholder="AI powered search..."
-        />
-        <button className="discover__search-ai">
-          <img src={AiGif} alt="AI Search" />
-        </button>
-      </div>
+      <Search />
       <TabNavigation
         tabs={tabs}
         activeTab={activeTab}
         onTabChange={handleTabChange}
       />
       {activeTab === "Leaders" ? (
-        loading ? (
-          <>
-            <h2 className="discover__section-title">Top 3 Leaders</h2>
-            <div className="discover__top-leaders">
-              {[...Array(3)].map((_, index) => (
-                <SkeletonCard key={index} large showRank />
-              ))}
-            </div>
-
-            <h2 className="discover__section-title">AI Suggested Leaders</h2>
-            <div className="discover__leaders-grid">
-              {[...Array(5)].map((_, index) => (
-                <SkeletonCard key={`ai-${index}`} />
-              ))}
-            </div>
-
-            <h2 className="discover__section-title">Top Earners</h2>
-            <div className="discover__leaders-grid">
-              {[...Array(5)].map((_, index) => (
-                <SkeletonCard key={`earners-${index}`} />
-              ))}
-            </div>
-
-            <h2 className="discover__section-title">Most Popular</h2>
-            <div className="discover__leaders-grid">
-              {[...Array(5)].map((_, index) => (
-                <SkeletonCard key={`popular-${index}`} />
-              ))}
-            </div>
-          </>
-        ) : (
-          <>
-            <h2 className="discover__section-title">Top 3 Leaders</h2>
-            <div className="discover__top-leaders">
-              {topLeaders.map((leader, index) => (
-                <LeaderCard
-                  key={leader.id}
-                  leader={leader}
-                  rank={index + 1}
-                  onFollow={handleFollowToggle}
-                  large
-                />
-              ))}
-            </div>
-
-            <h2 className="discover__section-title">AI Suggested Leaders</h2>
-            <div className="discover__leaders-grid">
-              {aiSuggestedLeaders.map((leader) => (
-                <LeaderCard
-                  key={leader.id}
-                  leader={leader}
-                  onFollow={handleFollowToggle}
-                />
-              ))}
-            </div>
-
-            <h2 className="discover__section-title">Top Earners</h2>
-            <div className="discover__leaders-grid">
-              {topEarners.map((leader) => (
-                <LeaderCard
-                  key={leader.id}
-                  leader={leader}
-                  onFollow={handleFollowToggle}
-                />
-              ))}
-            </div>
-
-            <h2 className="discover__section-title">Most Popular</h2>
-            <div className="discover__leaders-grid">
-              {mostPopular.map((leader) => (
-                <LeaderCard
-                  key={leader.id}
-                  leader={leader}
-                  onFollow={handleFollowToggle}
-                />
-              ))}
-            </div>
-          </>
-        )
-      ) : loading ? (
-        <>
-          <h2 className="discover__section-title">Top Strategies</h2>
-          <div className="discover__top-leaders">
-            {[...Array(3)].map((_, index) => (
-              <SkeletonCard key={index} large showRank />
-            ))}
-          </div>
-
-          <h2 className="discover__section-title">AI Suggested Strategies</h2>
-          <div className="discover__leaders-grid">
-            {[...Array(5)].map((_, index) => (
-              <SkeletonCard key={`ai-${index}`} />
-            ))}
-          </div>
-
-          <h2 className="discover__section-title">Popular Strategies</h2>
-          <div className="discover__leaders-grid">
-            {[...Array(5)].map((_, index) => (
-              <SkeletonCard key={`popular-${index}`} />
-            ))}
-          </div>
-        </>
+        <LeadersSection
+          loading={loading}
+          leaders={leaders}
+          onFollow={handleFollowToggle}
+        />
       ) : (
-        <>
-          <h2 className="discover__section-title">Top Strategies</h2>
-          <div className="discover__top-leaders">
-            {topStrategies.map((strategy, index) => (
-              <StrategyCard
-                key={strategy.id}
-                strategy={strategy}
-                rank={index + 1}
-                onFollow={handleFollowToggle}
-                onCopy={handleCopyStrategy}
-                large
-              />
-            ))}
-          </div>
-
-          <h2 className="discover__section-title">AI Suggested Strategies</h2>
-          <div className="discover__leaders-grid">
-            {aiSuggestedStrategies.map((strategy) => (
-              <StrategyCard
-                key={strategy.id}
-                strategy={strategy}
-                onFollow={handleFollowToggle}
-                onCopy={handleCopyStrategy}
-              />
-            ))}
-          </div>
-
-          <h2 className="discover__section-title">Popular Strategies</h2>
-          <div className="discover__leaders-grid">
-            {popularStrategies.map((strategy) => (
-              <StrategyCard
-                key={strategy.id}
-                strategy={strategy}
-                onFollow={handleFollowToggle}
-                onCopy={handleCopyStrategy}
-              />
-            ))}
-          </div>
-        </>
+        <StrategiesSection
+          loading={loading}
+          strategies={strategies}
+          onFollow={handleFollowToggle}
+          onCopy={handleCopyStrategy}
+        />
       )}
     </div>
   );

--- a/src/pages/discover/components/LeaderCard/LeaderCard.css
+++ b/src/pages/discover/components/LeaderCard/LeaderCard.css
@@ -25,7 +25,7 @@
 }
 
 .leader-card--large .leader-card__info {
-  padding: 4rem 1.5rem 1.5rem;
+  padding: 5rem 1.5rem 1.5rem;
 }
 
 .leader-card__banner {
@@ -155,7 +155,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  padding: 3rem 1rem 1rem;
+  padding: 4.5rem 1rem 1rem;
   text-align: center;
 }
 
@@ -170,8 +170,43 @@
   gap: 0.5rem;
 }
 
+.leader-card__leader-name {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0;
+  padding: 0.25rem 0 0.75rem;
+}
+
 .leader-card--large .leader-card__name {
   font-size: var(--font-size-xl);
+}
+
+.leader-card--large .leader-card__leader-name {
+  font-size: 1rem;
+  padding: 0.5rem 0 1rem;
+}
+
+.leader-card__description {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0;
+  padding: 0 0.5rem;
+  line-height: 1.4;
+}
+
+.leader-card--large .leader-card__description {
+  font-size: 1rem;
+  padding: 0 1rem;
+}
+
+.leader-card__trade-type {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  background: rgba(91, 181, 249, 0.1);
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  display: inline-block;
+  margin: 0.5rem 0;
 }
 
 .leader-card__stats {
@@ -228,15 +263,46 @@
   }
 
   .leader-card__info {
-    padding: 4rem 1.25rem 1.25rem;
+    padding: 5rem 1.25rem 1.25rem;
+  }
+
+  .leader-card--large .leader-card__info {
+    padding: 5.5rem 1.5rem 1.5rem;
   }
 
   .leader-card__stats {
     gap: 2rem;
     margin: 0.75rem 0 1.25rem;
   }
+}
 
-  .leader-card__stat-value {
-    font-size: 1.5rem;
-  }
+.leader-card__stat-value {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.leader-card__copy-button {
+  width: 100%;
+  padding: 8px;
+  margin: 12px 0;
+  border-radius: 20px;
+  border: none;
+  background-color: #5bb5f9;
+  color: white;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.leader-card__copy-button:hover {
+  background-color: #4a91c7;
+}
+
+.leader-card__copy-button--copied {
+  background-color: #dc3545;
+}
+
+.leader-card__copy-button--copied:hover {
+  background-color: #c82333;
 }

--- a/src/pages/discover/components/LeadersSection/LeadersSection.tsx
+++ b/src/pages/discover/components/LeadersSection/LeadersSection.tsx
@@ -1,0 +1,118 @@
+import { useMemo } from "react";
+import LeaderCard from "../LeaderCard";
+import SkeletonCard from "../SkeletonCard";
+
+interface Leader {
+  id: string;
+  username: string;
+  avatar?: string;
+  copiers: number;
+  totalProfit: number;
+  winRate: number;
+  isFollowing: boolean;
+}
+
+interface LeadersSectionProps {
+  loading: boolean;
+  leaders: Leader[];
+  onFollow: (leaderId: string) => Promise<void>;
+}
+
+export default function LeadersSection({
+  loading,
+  leaders,
+  onFollow,
+}: LeadersSectionProps) {
+  // Memoized sections
+  const topLeaders = useMemo(() => {
+    return [...leaders]
+      .sort((a, b) => b.totalProfit - a.totalProfit)
+      .slice(0, 3);
+  }, [leaders]);
+
+  const aiSuggestedLeaders = useMemo(() => {
+    return [...leaders].sort((a, b) => b.winRate - a.winRate).slice(0, 5);
+  }, [leaders]);
+
+  const topEarners = useMemo(() => {
+    return [...leaders]
+      .sort((a, b) => b.totalProfit - a.totalProfit)
+      .slice(0, 5);
+  }, [leaders]);
+
+  const mostPopular = useMemo(() => {
+    return [...leaders].sort((a, b) => b.copiers - a.copiers).slice(0, 5);
+  }, [leaders]);
+
+  if (loading) {
+    return (
+      <>
+        <h2 className="discover__section-title">Top 3 Leaders</h2>
+        <div className="discover__top-leaders">
+          {[...Array(3)].map((_, index) => (
+            <SkeletonCard key={index} large showRank />
+          ))}
+        </div>
+
+        <h2 className="discover__section-title">AI Suggested Leaders</h2>
+        <div className="discover__leaders-grid">
+          {[...Array(5)].map((_, index) => (
+            <SkeletonCard key={`ai-${index}`} />
+          ))}
+        </div>
+
+        <h2 className="discover__section-title">Top Earners</h2>
+        <div className="discover__leaders-grid">
+          {[...Array(5)].map((_, index) => (
+            <SkeletonCard key={`earners-${index}`} />
+          ))}
+        </div>
+
+        <h2 className="discover__section-title">Most Popular</h2>
+        <div className="discover__leaders-grid">
+          {[...Array(5)].map((_, index) => (
+            <SkeletonCard key={`popular-${index}`} />
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="discover__section-title">Top 3 Leaders</h2>
+      <div className="discover__top-leaders">
+        {topLeaders.map((leader, index) => (
+          <LeaderCard
+            key={leader.id}
+            leader={leader}
+            rank={index + 1}
+            onFollow={onFollow}
+            large
+          />
+        ))}
+      </div>
+
+      <h2 className="discover__section-title">AI Suggested Leaders</h2>
+      <div className="discover__leaders-grid">
+        {aiSuggestedLeaders.map((leader) => (
+          <LeaderCard key={leader.id} leader={leader} onFollow={onFollow} />
+        ))}
+      </div>
+
+      <h2 className="discover__section-title">Top Earners</h2>
+      <div className="discover__leaders-grid">
+        {topEarners.map((leader) => (
+          <LeaderCard key={leader.id} leader={leader} onFollow={onFollow} />
+        ))}
+      </div>
+
+      <h2 className="discover__section-title">Most Popular</h2>
+      <div className="discover__leaders-grid">
+        {mostPopular.map((leader) => (
+          <LeaderCard key={leader.id} leader={leader} onFollow={onFollow} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/pages/discover/components/LeadersSection/index.ts
+++ b/src/pages/discover/components/LeadersSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LeadersSection";

--- a/src/pages/discover/components/Search/Search.css
+++ b/src/pages/discover/components/Search/Search.css
@@ -1,0 +1,30 @@
+.discover__search {
+  position: relative;
+  margin: 1rem 0;
+}
+
+.discover__search-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-size: 1rem;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.discover__search-ai {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.discover__search-ai img {
+  width: 24px;
+  height: 24px;
+}

--- a/src/pages/discover/components/Search/Search.tsx
+++ b/src/pages/discover/components/Search/Search.tsx
@@ -1,0 +1,17 @@
+import AiGif from "../../../../assets/icons/ai.gif";
+import "./Search.css";
+
+export default function Search() {
+  return (
+    <div className="discover__search">
+      <input
+        type="search"
+        className="discover__search-input"
+        placeholder="AI powered search..."
+      />
+      <button className="discover__search-ai">
+        <img src={AiGif} alt="AI Search" />
+      </button>
+    </div>
+  );
+}

--- a/src/pages/discover/components/Search/index.ts
+++ b/src/pages/discover/components/Search/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Search";

--- a/src/pages/discover/components/StrategiesSection/StrategiesSection.tsx
+++ b/src/pages/discover/components/StrategiesSection/StrategiesSection.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import StrategyCard from "../StrategyCard";
+import SkeletonCard from "../SkeletonCard";
+
+interface Strategy {
+  id: string;
+  leaderId: string;
+  accountId: string;
+  name: string;
+  description: string;
+  tradeType: string;
+  copiers: string[];
+  leader?: {
+    username: string;
+    displayName: string;
+    profilePicture?: string;
+  };
+  currency?: string;
+  isFollowing?: boolean;
+  isCopying?: boolean;
+}
+
+interface StrategiesSectionProps {
+  loading: boolean;
+  strategies: Strategy[];
+  onFollow: (leaderId: string) => Promise<void>;
+  onCopy: (strategyId: string) => Promise<void>;
+}
+
+export default function StrategiesSection({
+  loading,
+  strategies,
+  onFollow,
+  onCopy,
+}: StrategiesSectionProps) {
+  // Strategy sections
+  const topStrategies = useMemo(() => {
+    return [...strategies]
+      .sort((a, b) => b.copiers.length - a.copiers.length)
+      .slice(0, 3);
+  }, [strategies]);
+
+  const aiSuggestedStrategies = useMemo(() => {
+    return [...strategies]
+      .sort((a, b) => b.copiers.length - a.copiers.length)
+      .slice(0, 5);
+  }, [strategies]);
+
+  const popularStrategies = useMemo(() => {
+    return [...strategies]
+      .sort((a, b) => b.copiers.length - a.copiers.length)
+      .slice(5, 10);
+  }, [strategies]);
+
+  if (loading) {
+    return (
+      <>
+        <h2 className="discover__section-title">Top Strategies</h2>
+        <div className="discover__top-leaders">
+          {[...Array(3)].map((_, index) => (
+            <SkeletonCard key={index} large showRank />
+          ))}
+        </div>
+
+        <h2 className="discover__section-title">AI Suggested Strategies</h2>
+        <div className="discover__leaders-grid">
+          {[...Array(5)].map((_, index) => (
+            <SkeletonCard key={`ai-${index}`} />
+          ))}
+        </div>
+
+        <h2 className="discover__section-title">Popular Strategies</h2>
+        <div className="discover__leaders-grid">
+          {[...Array(5)].map((_, index) => (
+            <SkeletonCard key={`popular-${index}`} />
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="discover__section-title">Top Strategies</h2>
+      <div className="discover__top-leaders">
+        {topStrategies.map((strategy, index) => (
+          <StrategyCard
+            key={strategy.id}
+            strategy={strategy}
+            rank={index + 1}
+            onFollow={onFollow}
+            onCopy={onCopy}
+            large
+          />
+        ))}
+      </div>
+
+      <h2 className="discover__section-title">AI Suggested Strategies</h2>
+      <div className="discover__leaders-grid">
+        {aiSuggestedStrategies.map((strategy) => (
+          <StrategyCard
+            key={strategy.id}
+            strategy={strategy}
+            onFollow={onFollow}
+            onCopy={onCopy}
+          />
+        ))}
+      </div>
+
+      <h2 className="discover__section-title">Popular Strategies</h2>
+      <div className="discover__leaders-grid">
+        {popularStrategies.map((strategy) => (
+          <StrategyCard
+            key={strategy.id}
+            strategy={strategy}
+            onFollow={onFollow}
+            onCopy={onCopy}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/pages/discover/components/StrategiesSection/index.ts
+++ b/src/pages/discover/components/StrategiesSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StrategiesSection";

--- a/src/pages/discover/components/StrategyCard/StrategyCard.tsx
+++ b/src/pages/discover/components/StrategyCard/StrategyCard.tsx
@@ -1,0 +1,113 @@
+import { FC } from "react";
+import Tick from "../../../../assets/icons/Tick";
+import Plus from "../../../../assets/icons/Plus";
+import Trophy from "../../../../assets/icons/Trophy";
+import "../LeaderCard/LeaderCard.css";
+
+interface Strategy {
+  id: string;
+  leaderId: string;
+  accountId: string;
+  name: string;
+  description: string;
+  tradeType: string;
+  copiers: string[];
+  leader?: {
+    username: string;
+    displayName: string;
+    profilePicture?: string;
+  };
+  currency?: string;
+  isFollowing?: boolean;
+  isCopying?: boolean;
+}
+
+interface StrategyCardProps {
+  strategy: Strategy;
+  rank?: number;
+  onFollow: (id: string) => void;
+  onCopy: (id: string) => void;
+  large?: boolean;
+}
+
+const StrategyCard: FC<StrategyCardProps> = ({
+  strategy,
+  rank,
+  onFollow,
+  onCopy,
+  large,
+}) => {
+  const formatCopiers = (count: number) => {
+    return new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      compactDisplay: "short",
+    }).format(count);
+  };
+
+  return (
+    <div className={`leader-card ${large ? "leader-card--large" : ""}`}>
+      {rank && (
+        <div className="leader-card__rank">
+          {rank <= 3 && <Trophy className="leader-card__trophy" />}#{rank}
+        </div>
+      )}
+      <div className="leader-card__banner">
+        <div className="leader-card__avatar">
+          <div className="leader-card__avatar-wrapper">
+            {strategy.leader?.profilePicture ? (
+              <img
+                src={strategy.leader.profilePicture}
+                alt={strategy.leader.displayName}
+                className="leader-card__avatar-img"
+              />
+            ) : (
+              <div className="leader-card__avatar-placeholder">
+                {strategy.leader?.displayName.slice(0, 2).toUpperCase() || "ST"}
+              </div>
+            )}
+            <button
+              className="leader-card__follow-icon"
+              onClick={() => onFollow(strategy.leaderId)}
+            >
+              {strategy.isFollowing ? <Tick /> : <Plus />}
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="leader-card__info">
+        <h3 className="leader-card__name">{strategy.name}</h3>
+        <p className="leader-card__leader-name">
+          {strategy.leader?.displayName}
+        </p>
+        <span className="leader-card__trade-type">
+          {strategy.tradeType
+            .split("_")
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(" ")}
+        </span>
+        <button
+          className={`leader-card__copy-button ${
+            strategy.isCopying ? "leader-card__copy-button--copied" : ""
+          }`}
+          onClick={() => onCopy(strategy.id)}
+        >
+          {strategy.isCopying ? "Stop Copying" : "Copy Strategy"}
+        </button>
+        <div className="leader-card__stats">
+          <div className="leader-card__stat">
+            <span className="leader-card__stat-label">Currency</span>
+            <span className="leader-card__stat-value">{strategy.currency}</span>
+          </div>
+          <div className="leader-card__stat">
+            <span className="leader-card__stat-label">Copiers</span>
+            <span className="leader-card__stat-value">
+              {formatCopiers(strategy.copiers.length)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StrategyCard;

--- a/src/pages/discover/components/StrategyCard/index.ts
+++ b/src/pages/discover/components/StrategyCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StrategyCard";


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new "Strategies" tab to the Discover page, allowing users to view and copy trading strategies. Users can now follow/unfollow leaders and copy/stop copying strategies.

New Features:
- Added a "Strategies" tab on the Discover page to display available trading strategies.

Tests:
- Updated tests to cover the new Strategies tab and its components.