### PR TITLE
Fix env variables

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VITE_API_URL=http://localhost:3000
+VITE_LLM_SERVER_URL=http://localhost:3000
 VITE_JSON_SERVER_URL=http://localhost:3001

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build Frontend
       run: npm run build
       env:
-        VITE_API_URL: http://localhost:3000
+        VITE_LLM_SERVER_URL: http://localhost:3000
         VITE_JSON_SERVER_URL: http://localhost:3001
 
     - name: Set up Docker Buildx
@@ -38,7 +38,7 @@ jobs:
         cache-to: type=gha,mode=max
         target: development
         build-args: |
-          VITE_API_URL=http://localhost:3000
+          VITE_LLM_SERVER_URL=http://localhost:3000
           VITE_JSON_SERVER_URL=http://localhost:3001
 
   json-server:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 .env
+.env.example

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -12,11 +12,11 @@ FROM node:18-alpine as build
 WORKDIR /app
 
 # Add build arguments
-ARG VITE_API_URL
+ARG VITE_LLM_SERVER_URL
 ARG VITE_JSON_SERVER_URL
 
 # Convert to environment variables
-ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_LLM_SERVER_URL=$VITE_LLM_SERVER_URL
 ENV VITE_JSON_SERVER_URL=$VITE_JSON_SERVER_URL
 
 COPY package*.json ./
@@ -32,7 +32,7 @@ COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 
 # Set environment variable for LLM server URL
-ENV LLM_SERVER_URL=http://localhost:3000/
+ENV VITE_LLM_SERVER_URL=http://localhost:3000/
 
 EXPOSE 80
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -37,4 +37,4 @@ ENV VITE_LLM_SERVER_URL=http://localhost:3000/
 EXPOSE 80
 
 # Use environment variable substitution
-CMD ["/bin/sh", "-c", "envsubst '${LLM_SERVER_URL}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '${VITE_LLM_SERVER_URL}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/README.docker.md
+++ b/README.docker.md
@@ -70,7 +70,7 @@ For staging and production environments in Render:
 3. Service-Specific Configuration:
    - Frontend:
      ```
-     VITE_API_URL=https://your-llm-server.onrender.com
+     VITE_LLM_SERVER_URL=https://your-llm-server.onrender.com
      VITE_JSON_SERVER_URL=https://your-json-server.onrender.com
      ```
    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile.frontend
       target: ${NODE_ENV:-development}
       args:
-        - VITE_API_URL=${VITE_API_URL:-http://localhost:3000}
+        - VITE_LLM_SERVER_URL=${VITE_LLM_SERVER_URL:-http://localhost:3000}
         - VITE_JSON_SERVER_URL=${VITE_JSON_SERVER_URL:-http://localhost:3001}
     ports:
       - "5173:5173"  # Development port
@@ -14,7 +14,7 @@ services:
       - ./:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=${VITE_API_URL:-http://localhost:3000}
+      - VITE_LLM_SERVER_URL=${VITE_LLM_SERVER_URL:-http://localhost:3000}
       - VITE_JSON_SERVER_URL=${VITE_JSON_SERVER_URL:-http://localhost:3001}
     depends_on:
       - llm-server

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,7 +10,7 @@ server {
 
     # Proxy /api requests to the LLM server
     location /api/ {
-        proxy_pass ${LLM_SERVER_URL};
+        proxy_pass ${VITE_LLM_SERVER_URL};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/src/modules/feed/services/aiService.ts
+++ b/src/modules/feed/services/aiService.ts
@@ -1,8 +1,8 @@
 import { AIInsight } from "@/types/ai.types";
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_LLM_SERVER_URL;
 if (!API_URL) {
-    throw new Error('VITE_API_URL environment variable is not set');
+    throw new Error('VITE_LLM_SERVER_URL environment variable is not set');
 }
 
 interface SingleInsightResponse {


### PR DESCRIPTION
## Summary by Sourcery

Rename the `VITE_API_URL` environment variable to `VITE_LLM_SERVER_URL` across the application, CI/CD pipelines, and documentation.

Bug Fixes:
- Correct the environment variable name used across the application and CI/CD pipelines from `VITE_API_URL` to `VITE_LLM_SERVER_URL`

Build:
- Update the build process to use `VITE_LLM_SERVER_URL` instead of `VITE_API_URL`

CI:
- Update the CI workflow to use `VITE_LLM_SERVER_URL` instead of `VITE_API_URL`

Deployment:
- Update the deployment configuration to use `VITE_LLM_SERVER_URL` instead of `VITE_API_URL`

Documentation:
- Update the documentation to reflect the change in environment variable name from `VITE_API_URL` to `VITE_LLM_SERVER_URL`