### PR TITLE
fix: llm-server restart fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     build:
       context: .
       dockerfile: llm-server/Dockerfile
+      target: ${NODE_ENV:-development}
     ports:
       - "3000:3000"
     volumes:

--- a/llm-server/Dockerfile
+++ b/llm-server/Dockerfile
@@ -1,4 +1,22 @@
-FROM node:18-alpine
+# Development stage
+FROM node:18-alpine as development
+
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY llm-server/package*.json ./
+COPY llm-server/tsconfig.json ./
+RUN npm install
+
+# Copy source code
+COPY llm-server/src ./src
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]
+
+# Production stage
+FROM node:18-alpine as production
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce multi-stage builds for the llm-server. Use environment variables to select the appropriate Docker build target. This fixes unexpected restarts of the server.

Bug Fixes:
- Fix llm-server restarts by building separate development and production stages, and using environment variables to select the appropriate target during the build process

Build:
- Introduce multi-stage builds for the llm-server, separating development and production stages.
- Use `${NODE_ENV:-development}` as the build target for the llm-server Dockerfile, allowing environment variables to control the build stage.