### PR TITLE
Refactor Discover and Profile pages to use the re-usable StrategyListItem component

### DIFF
--- a/src/components/strategy/StrategyListItem/StrategyListItem.css
+++ b/src/components/strategy/StrategyListItem/StrategyListItem.css
@@ -2,15 +2,32 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: var(--color-background-secondary);
+  background: var(--background-primary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 1rem;
   transition: transform 0.2s ease;
+  position: relative;
 }
 
 .strategy-list__item:hover {
   transform: translateY(-2px);
+}
+
+.strategy-list__rank {
+  background: var(--background-secondary);
+  padding: 0.5rem 1rem;
+  border-radius: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.strategy-list__trophy {
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-warning);
 }
 
 .strategy-list__header {
@@ -24,13 +41,31 @@
 .strategy-list__header-main {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 1rem;
   width: 100%;
 }
 
-.strategy-list__description {
+.strategy-list__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.strategy-list__title h4 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.strategy-list__username {
   font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.strategy-list__description {
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
   line-height: 1.5;
   margin: 0;
@@ -40,8 +75,8 @@
 
 .strategy-list__stats {
   display: flex;
-  gap: 2rem;
-  padding: 0.8rem;
+  gap: 1.5rem;
+  padding: 0.4rem;
   background-color: #00d0ff10;
   border-radius: 1rem;
 }
@@ -61,12 +96,15 @@
 }
 
 .strategy-list__stat-label {
-  font-size: 0.875rem;
+  font-size: var(--font-size-xs);
   color: #6b7280;
 }
 
 .strategy-list__meta {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 }
 
 .strategy-list__risk {
@@ -100,6 +138,7 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
+  padding: 0.5rem 1rem;
 }
 
 .strategy-list__copy-btn--primary {

--- a/src/components/strategy/StrategyListItem/StrategyListItem.tsx
+++ b/src/components/strategy/StrategyListItem/StrategyListItem.tsx
@@ -1,13 +1,23 @@
 import { FC } from 'react';
 import type { Strategy } from '@/types/strategy.types';
+
+interface ExtendedStrategy extends Strategy {
+  leader?: {
+    username: string;
+    displayName: string;
+    profilePicture?: string;
+  };
+}
+import Trophy from '@/assets/icons/Trophy';
 import './StrategyListItem.css';
 
 interface StrategyListItemProps {
-  strategy: Strategy;
+  strategy: ExtendedStrategy;
   showCopyButton?: boolean;
   isCopying?: boolean;
   onCopy?: (strategyId: string, isCopying: boolean) => void;
   onClick?: (strategyId: string) => void;
+  rank?: number;
 }
 
 const StrategyListItem: FC<StrategyListItemProps> = ({
@@ -16,6 +26,7 @@ const StrategyListItem: FC<StrategyListItemProps> = ({
   isCopying = false,
   onCopy,
   onClick,
+  rank,
 }) => {
   const getRiskLevelClass = (riskLevel: string) => {
     const level = riskLevel.toLowerCase();
@@ -24,13 +35,18 @@ const StrategyListItem: FC<StrategyListItemProps> = ({
 
   return (
     <div
-      className="strategy-list__item"
+      className={`strategy-list__item ${rank ? 'strategy-list__item--ranked' : ''}`}
       onClick={() => onClick?.(strategy.id)}
       style={{ cursor: 'pointer' }}
     >
       <div className="strategy-list__header">
         <div className="strategy-list__header-main">
-          <h4>{strategy.name}</h4>
+          <div className="strategy-list__title">
+            <h4>{strategy.name}</h4>
+            {strategy.leader && (
+              <span className="strategy-list__username">by @{strategy.leader.username}</span>
+            )}
+          </div>
           {showCopyButton && onCopy && (
             <button
               className={`strategy-list__copy-btn ${
@@ -71,10 +87,19 @@ const StrategyListItem: FC<StrategyListItemProps> = ({
           <span className="strategy-list__stat-value">{strategy.performance.averageProfit}%</span>
           <span className="strategy-list__stat-label">Avg. Profit</span>
         </div>
+        <div className="strategy-list__stat-item">
+          <span className="strategy-list__stat-value">{strategy.copiers.length}</span>
+          <span className="strategy-list__stat-label">Copiers</span>
+        </div>
       </div>
 
       <div className="strategy-list__meta">
         <span className={getRiskLevelClass(strategy.riskLevel)}>{strategy.riskLevel} Risk</span>
+        {rank && (
+          <div className="strategy-list__rank">
+            <Trophy className="strategy-list__trophy" />#{rank}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/strategy/StrategyListItem/index.ts
+++ b/src/components/strategy/StrategyListItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StrategyListItem';

--- a/src/modules/profile/components/StrategyList/StrategyList.tsx
+++ b/src/modules/profile/components/StrategyList/StrategyList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Strategy } from '@/types/strategy.types';
 import { useAuth } from '@/context/AuthContext';
-import StrategyListItem from './components/StrategyListItem/StrategyListItem';
+import StrategyListItem from '@/components/strategy/StrategyListItem';
 import './StrategyList.css';
 
 interface StrategyListProps {

--- a/src/pages/discover/Discover.css
+++ b/src/pages/discover/Discover.css
@@ -98,14 +98,14 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto 3rem;
   padding: 0 2rem;
 }
 
 .discover__leaders-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
   margin: 0 auto 2rem;
   max-width: 1400px;
@@ -113,28 +113,19 @@
 }
 
 /* Responsive styles */
-@media (max-width: 1400px) {
-  .discover__leaders-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
 @media (max-width: 1200px) {
+  .discover__top-leaders,
   .discover__leaders-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
+    padding: 0 1.5rem;
   }
 }
 
 @media (max-width: 768px) {
-  .discover__top-leaders {
-    grid-template-columns: repeat(2, 1fr);
-    padding: 1rem;
-    gap: 1.5rem;
-  }
-
+  .discover__top-leaders,
   .discover__leaders-grid {
-    grid-template-columns: repeat(2, 1fr);
-    padding: 1rem;
+    grid-template-columns: 1fr;
+    padding: 0 1rem;
     gap: 1rem;
   }
 }
@@ -153,14 +144,9 @@
     margin-bottom: 1.5rem;
   }
 
-  .discover__top-leaders {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem;
-    padding: 0;
-  }
-
+  .discover__top-leaders,
   .discover__leaders-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
     gap: 0.75rem;
     padding: 0;
   }

--- a/src/pages/discover/components/StrategiesSection/StrategiesSection.tsx
+++ b/src/pages/discover/components/StrategiesSection/StrategiesSection.tsx
@@ -1,15 +1,11 @@
-import { useMemo } from "react";
-import StrategyCard from "../StrategyCard";
-import SkeletonCard from "../SkeletonCard";
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import StrategyListItem from '@/components/strategy/StrategyListItem';
+import SkeletonCard from '../SkeletonCard';
 
-interface Strategy {
-  id: string;
-  leaderId: string;
-  accountId: string;
-  name: string;
-  description: string;
-  tradeType: string;
-  copiers: string[];
+import type { Strategy } from '@/types/strategy.types';
+
+interface ExtendedStrategy extends Strategy {
   leader?: {
     username: string;
     displayName: string;
@@ -22,17 +18,12 @@ interface Strategy {
 
 interface StrategiesSectionProps {
   loading: boolean;
-  strategies: Strategy[];
-  onFollow: (leaderId: string) => Promise<void>;
+  strategies: ExtendedStrategy[];
   onCopy: (strategyId: string) => Promise<void>;
 }
 
-export default function StrategiesSection({
-  loading,
-  strategies,
-  onFollow,
-  onCopy,
-}: StrategiesSectionProps) {
+export default function StrategiesSection({ loading, strategies, onCopy }: StrategiesSectionProps) {
+  const navigate = useNavigate();
   // Strategy sections
   const topStrategies = useMemo(() => {
     return strategies.slice(0, 3);
@@ -78,37 +69,42 @@ export default function StrategiesSection({
       <h2 className="discover__section-title">Top Strategies</h2>
       <div className="discover__top-leaders">
         {topStrategies.map((strategy, index) => (
-          <StrategyCard
+          <StrategyListItem
             key={strategy.id}
             strategy={strategy}
             rank={index + 1}
-            onFollow={onFollow}
-            onCopy={onCopy}
-            large
+            showCopyButton={true}
+            isCopying={strategy.isCopying}
+            onCopy={(strategyId: string) => onCopy(strategyId)}
+            onClick={(strategyId: string) => navigate(`/strategies/${strategyId}`)}
           />
         ))}
       </div>
 
       <h2 className="discover__section-title">AI Suggested Strategies</h2>
       <div className="discover__leaders-grid">
-        {aiSuggestedStrategies.map((strategy) => (
-          <StrategyCard
+        {aiSuggestedStrategies.map(strategy => (
+          <StrategyListItem
             key={strategy.id}
             strategy={strategy}
-            onFollow={onFollow}
-            onCopy={onCopy}
+            showCopyButton={true}
+            isCopying={strategy.isCopying}
+            onCopy={(strategyId: string) => onCopy(strategyId)}
+            onClick={(strategyId: string) => navigate(`/strategies/${strategyId}`)}
           />
         ))}
       </div>
 
       <h2 className="discover__section-title">Popular Strategies</h2>
       <div className="discover__leaders-grid">
-        {popularStrategies.map((strategy) => (
-          <StrategyCard
+        {popularStrategies.map(strategy => (
+          <StrategyListItem
             key={strategy.id}
             strategy={strategy}
-            onFollow={onFollow}
-            onCopy={onCopy}
+            showCopyButton={true}
+            isCopying={strategy.isCopying}
+            onCopy={(strategyId: string) => onCopy(strategyId)}
+            onClick={(strategyId: string) => navigate(`/strategies/${strategyId}`)}
           />
         ))}
       </div>

--- a/src/pages/discover/components/StrategiesSection/StrategiesSection.tsx
+++ b/src/pages/discover/components/StrategiesSection/StrategiesSection.tsx
@@ -2,19 +2,7 @@ import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import StrategyListItem from '@/components/strategy/StrategyListItem';
 import SkeletonCard from '../SkeletonCard';
-
-import type { Strategy } from '@/types/strategy.types';
-
-interface ExtendedStrategy extends Strategy {
-  leader?: {
-    username: string;
-    displayName: string;
-    profilePicture?: string;
-  };
-  currency?: string;
-  isFollowing?: boolean;
-  isCopying?: boolean;
-}
+import type { ExtendedStrategy } from '@/types/strategy.types';
 
 interface StrategiesSectionProps {
   loading: boolean;

--- a/src/types/strategy.types.ts
+++ b/src/types/strategy.types.ts
@@ -31,4 +31,15 @@ export interface Strategy {
   };
 }
 
+export interface ExtendedStrategy extends Strategy {
+  leader?: {
+    username: string;
+    displayName: string;
+    profilePicture?: string;
+  };
+  currency?: string;
+  isFollowing?: boolean;
+  isCopying?: boolean;
+}
+
 export default Strategy;


### PR DESCRIPTION
## Summary by Sourcery

Refactored the Discover and Profile pages to use the reusable StrategyListItem component, enhancing code maintainability and consistency across the application. This change replaces the StrategyCard component with the StrategyListItem component in the Discover page and the StrategyListItem component in the Profile page.

Enhancements:
- Replaced the StrategyCard component with the StrategyListItem component in the Discover and Profile pages to promote code reuse and consistency.
- Improved the StrategyListItem component to include the strategy's rank.