### PR TITLE
Kate/upgrade to leader

### DIFF
--- a/json-server/data/db.json
+++ b/json-server/data/db.json
@@ -17,7 +17,18 @@
         "totalTrades": 156
       },
       "createdAt": "2024-01-01T00:00:00Z",
-      "updatedAt": "2024-01-01T00:00:00Z"
+      "updatedAt": "2024-01-01T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader2",
@@ -36,7 +47,18 @@
         "totalTrades": 98
       },
       "createdAt": "2024-01-02T00:00:00Z",
-      "updatedAt": "2024-01-02T00:00:00Z"
+      "updatedAt": "2024-01-02T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "copier1",
@@ -74,7 +96,18 @@
       "following": ["leader1"],
       "accounts": ["acc5"],
       "createdAt": "2024-01-04T00:00:00Z",
-      "updatedAt": "2024-01-04T00:00:00Z"
+      "updatedAt": "2024-01-04T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "copier3",
@@ -87,7 +120,18 @@
       "following": ["leader1", "leader2"],
       "accounts": ["acc6", "acc7"],
       "createdAt": "2024-01-05T00:00:00Z",
-      "updatedAt": "2024-01-05T00:00:00Z"
+      "updatedAt": "2024-01-05T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader3",
@@ -100,7 +144,18 @@
       "following": [],
       "accounts": ["acc8"],
       "createdAt": "2024-01-06T00:00:00Z",
-      "updatedAt": "2024-01-06T00:00:00Z"
+      "updatedAt": "2024-01-06T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader4",
@@ -113,7 +168,18 @@
       "following": [],
       "accounts": ["acc9"],
       "createdAt": "2024-01-07T00:00:00Z",
-      "updatedAt": "2024-01-07T00:00:00Z"
+      "updatedAt": "2024-01-07T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader5",
@@ -126,7 +192,18 @@
       "following": [],
       "accounts": ["acc10"],
       "createdAt": "2024-01-08T00:00:00Z",
-      "updatedAt": "2024-01-08T00:00:00Z"
+      "updatedAt": "2024-01-08T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader6",
@@ -139,7 +216,18 @@
       "following": [],
       "accounts": ["acc11"],
       "createdAt": "2024-01-09T00:00:00Z",
-      "updatedAt": "2024-01-09T00:00:00Z"
+      "updatedAt": "2024-01-09T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader7",
@@ -152,7 +240,18 @@
       "following": [],
       "accounts": ["acc12"],
       "createdAt": "2024-01-10T00:00:00Z",
-      "updatedAt": "2024-01-10T00:00:00Z"
+      "updatedAt": "2024-01-10T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader8",
@@ -165,7 +264,18 @@
       "following": [],
       "accounts": ["acc13"],
       "createdAt": "2024-01-11T00:00:00Z",
-      "updatedAt": "2024-01-11T00:00:00Z"
+      "updatedAt": "2024-01-11T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader9",
@@ -178,7 +288,18 @@
       "following": [],
       "accounts": ["acc14"],
       "createdAt": "2024-01-12T00:00:00Z",
-      "updatedAt": "2024-01-12T00:00:00Z"
+      "updatedAt": "2024-01-12T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader10",
@@ -191,7 +312,18 @@
       "following": [],
       "accounts": ["acc15"],
       "createdAt": "2024-01-13T00:00:00Z",
-      "updatedAt": "2024-01-13T00:00:00Z"
+      "updatedAt": "2024-01-13T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader11",
@@ -204,7 +336,18 @@
       "following": [],
       "accounts": ["acc16"],
       "createdAt": "2024-01-14T00:00:00Z",
-      "updatedAt": "2024-01-14T00:00:00Z"
+      "updatedAt": "2024-01-14T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader12",
@@ -217,7 +360,18 @@
       "following": [],
       "accounts": ["acc17"],
       "createdAt": "2024-01-15T00:00:00Z",
-      "updatedAt": "2024-01-15T00:00:00Z"
+      "updatedAt": "2024-01-15T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader13",
@@ -230,7 +384,18 @@
       "following": [],
       "accounts": ["acc18"],
       "createdAt": "2024-01-16T00:00:00Z",
-      "updatedAt": "2024-01-16T00:00:00Z"
+      "updatedAt": "2024-01-16T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader14",
@@ -243,7 +408,18 @@
       "following": [],
       "accounts": ["acc19"],
       "createdAt": "2024-01-17T00:00:00Z",
-      "updatedAt": "2024-01-17T00:00:00Z"
+      "updatedAt": "2024-01-17T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader15",
@@ -256,7 +432,18 @@
       "following": [],
       "accounts": ["acc20"],
       "createdAt": "2024-01-18T00:00:00Z",
-      "updatedAt": "2024-01-18T00:00:00Z"
+      "updatedAt": "2024-01-18T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader16",
@@ -269,7 +456,18 @@
       "following": [],
       "accounts": ["acc21"],
       "createdAt": "2024-01-19T00:00:00Z",
-      "updatedAt": "2024-01-19T00:00:00Z"
+      "updatedAt": "2024-01-19T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     },
     {
       "id": "leader17",
@@ -282,7 +480,18 @@
       "following": [],
       "accounts": ["acc22"],
       "createdAt": "2024-01-20T00:00:00Z",
-      "updatedAt": "2024-01-20T00:00:00Z"
+      "updatedAt": "2024-01-20T00:00:00Z",
+      "tradingPreferences": {
+        "riskTolerance": "medium",
+        "investmentStyle": "moderate",
+        "preferredMarkets": [],
+        "preferredTradeTypes": [],
+        "tradingFrequency": "weekly",
+        "maxDrawdown": 20,
+        "targetReturn": 15,
+        "minStake": 10,
+        "maxStake": 100
+      }
     }
   ],
   "currencyAccounts": [

--- a/src/assets/icons/EditIcon.tsx
+++ b/src/assets/icons/EditIcon.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const EditIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M11.5 2.5L13.5 4.5M12.5 1.5L8.5 5.5L2 12V14H4L10.5 7.5L14.5 3.5C14.5 2.5 13.5 1.5 12.5 1.5Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default EditIcon;

--- a/src/assets/icons/EditIcon.tsx
+++ b/src/assets/icons/EditIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const EditIcon = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path

--- a/src/components/modal/Modal/Modal.css
+++ b/src/components/modal/Modal/Modal.css
@@ -1,0 +1,114 @@
+.modal__overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  opacity: 0;
+}
+
+.modal__overlay.entering {
+  animation: fadeIn 0.2s ease-out forwards;
+}
+
+.modal__overlay.exiting {
+  animation: fadeOut 0.2s ease-in forwards;
+}
+
+.modal__container {
+  background-color: white;
+  border-radius: 1rem;
+  width: 90%;
+  max-width: 500px;
+  max-height: 95vh;
+  overflow-y: auto;
+  transform: scale(0.9);
+  opacity: 0;
+}
+
+.modal__container.entering {
+  animation: zoomIn 0.2s ease-out forwards;
+}
+
+.modal__container.exiting {
+  animation: zoomOut 0.2s ease-in forwards;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.modal__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0;
+}
+
+.modal__close {
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: #6b7280;
+  transition: color 0.2s;
+  border-radius: 0.375rem;
+}
+
+.modal__close:hover {
+  color: #1f2937;
+  background-color: #f3f4f6;
+}
+
+.modal__content {
+  padding: 1.5rem;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes zoomIn {
+  from {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes zoomOut {
+  from {
+    transform: scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+}

--- a/src/components/modal/Modal/Modal.tsx
+++ b/src/components/modal/Modal/Modal.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import CloseIcon from '@/assets/icons/CloseIcon';
+import './Modal.css';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExited?: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, onExited, title, children }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [animationState, setAnimationState] = useState<'entering' | 'exiting' | ''>('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsVisible(true);
+      setAnimationState('entering');
+      document.body.style.overflow = 'hidden';
+    } else {
+      setAnimationState('exiting');
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  const handleAnimationEnd = () => {
+    if (animationState === 'exiting') {
+      setIsVisible(false);
+      onExited?.();
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div className={`modal__overlay ${animationState}`} onClick={handleBackdropClick}>
+      <div className={`modal__container ${animationState}`} onAnimationEnd={handleAnimationEnd}>
+        <div className="modal__header">
+          <h2 className="modal__title">{title}</h2>
+          <button className="modal__close" onClick={onClose} aria-label="Close modal">
+            <CloseIcon />
+          </button>
+        </div>
+        <div className="modal__content">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/modal/Modal/index.ts
+++ b/src/components/modal/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/src/modules/profile/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/modules/profile/components/ProfileHeader/ProfileHeader.tsx
@@ -4,6 +4,7 @@ import ProfileStats from './components/ProfileStats';
 import ProfilePerformance from './components/ProfilePerformance';
 import ProfileTradingPreferences from './components/ProfileTradingPreferences';
 import './ProfileHeader.css';
+import { UserType } from '@/types/user';
 
 interface ProfileHeaderProps {
   profile: User;
@@ -11,6 +12,7 @@ interface ProfileHeaderProps {
   isFollowing: boolean;
   onFollow: () => Promise<void>;
   onUnfollow: () => Promise<void>;
+  onProfileUpdate?: (updatedProfile: User) => void;
 }
 
 const ProfileHeader = ({
@@ -19,8 +21,10 @@ const ProfileHeader = ({
   isFollowing,
   onFollow,
   onUnfollow,
+  onProfileUpdate,
 }: ProfileHeaderProps) => {
   const {
+    id,
     username,
     profilePicture,
     userType,
@@ -31,6 +35,15 @@ const ProfileHeader = ({
     tradingPreferences,
   } = profile;
 
+  const handleUpgrade = () => {
+    if (onProfileUpdate) {
+      onProfileUpdate({
+        ...profile,
+        userType: UserType.LEADER,
+      });
+    }
+  };
+
   return (
     <div className="profile-header">
       <div className="profile-header__info">
@@ -39,10 +52,12 @@ const ProfileHeader = ({
           displayName={displayName}
           profilePicture={profilePicture}
           userType={userType}
+          userId={id}
           isOwnProfile={isOwnProfile}
           isFollowing={isFollowing}
           onFollow={onFollow}
           onUnfollow={onUnfollow}
+          onUpgrade={handleUpgrade}
         />
         <ProfileStats
           followers={followers}

--- a/src/modules/profile/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/modules/profile/components/ProfileHeader/ProfileHeader.tsx
@@ -68,7 +68,20 @@ const ProfileHeader = ({
         {userType === 'leader' && profile.performance && (
           <ProfilePerformance performance={profile.performance} />
         )}
-        {tradingPreferences && <ProfileTradingPreferences preferences={tradingPreferences} />}
+        {tradingPreferences && (
+          <ProfileTradingPreferences
+            preferences={tradingPreferences}
+            isOwnProfile={isOwnProfile}
+            onUpdate={newPreferences => {
+              if (onProfileUpdate) {
+                onProfileUpdate({
+                  ...profile,
+                  tradingPreferences: newPreferences,
+                });
+              }
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/modules/profile/components/ProfileHeader/ProfileHeader.tsx
+++ b/src/modules/profile/components/ProfileHeader/ProfileHeader.tsx
@@ -1,59 +1,62 @@
-import type User from "@/types/user.types";
-import ProfileBasicInfo from "./components/ProfileBasicInfo";
-import ProfileStats from "./components/ProfileStats";
-import ProfilePerformance from "./components/ProfilePerformance";
-import "./ProfileHeader.css";
+import type User from '@/types/user.types';
+import ProfileBasicInfo from './components/ProfileBasicInfo';
+import ProfileStats from './components/ProfileStats';
+import ProfilePerformance from './components/ProfilePerformance';
+import ProfileTradingPreferences from './components/ProfileTradingPreferences';
+import './ProfileHeader.css';
 
 interface ProfileHeaderProps {
-    profile: User;
-    isOwnProfile: boolean;
-    isFollowing: boolean;
-    onFollow: () => Promise<void>;
-    onUnfollow: () => Promise<void>;
+  profile: User;
+  isOwnProfile: boolean;
+  isFollowing: boolean;
+  onFollow: () => Promise<void>;
+  onUnfollow: () => Promise<void>;
 }
 
 const ProfileHeader = ({
-    profile,
-    isOwnProfile,
-    isFollowing,
-    onFollow,
-    onUnfollow
+  profile,
+  isOwnProfile,
+  isFollowing,
+  onFollow,
+  onUnfollow,
 }: ProfileHeaderProps) => {
-    const { 
-        username, 
-        profilePicture, 
-        userType, 
-        followers = [], 
-        following = [],
-        strategies = [],
-        displayName
-    } = profile;
+  const {
+    username,
+    profilePicture,
+    userType,
+    followers = [],
+    following = [],
+    strategies = [],
+    displayName,
+    tradingPreferences,
+  } = profile;
 
-    return (
-        <div className="profile-header">
-                <div className="profile-header__info">
-                    <ProfileBasicInfo
-                        username={username}
-                        displayName={displayName}
-                        profilePicture={profilePicture}
-                        userType={userType}
-                        isOwnProfile={isOwnProfile}
-                        isFollowing={isFollowing}
-                        onFollow={onFollow}
-                        onUnfollow={onUnfollow}
-                    />
-                    <ProfileStats
-                        followers={followers}
-                        following={following}
-                        strategies={strategies}
-                        onFollowAction={onFollow}
-                    />
-                    {userType === "leader" && profile.performance && (
-                        <ProfilePerformance performance={profile.performance} />
-                    )}
-                </div>
-        </div>
-    );
+  return (
+    <div className="profile-header">
+      <div className="profile-header__info">
+        <ProfileBasicInfo
+          username={username}
+          displayName={displayName}
+          profilePicture={profilePicture}
+          userType={userType}
+          isOwnProfile={isOwnProfile}
+          isFollowing={isFollowing}
+          onFollow={onFollow}
+          onUnfollow={onUnfollow}
+        />
+        <ProfileStats
+          followers={followers}
+          following={following}
+          strategies={strategies}
+          onFollowAction={onFollow}
+        />
+        {userType === 'leader' && profile.performance && (
+          <ProfilePerformance performance={profile.performance} />
+        )}
+        {tradingPreferences && <ProfileTradingPreferences preferences={tradingPreferences} />}
+      </div>
+    </div>
+  );
 };
 
 export default ProfileHeader;

--- a/src/modules/profile/components/ProfileHeader/components/EditTradingPreferencesModal.tsx
+++ b/src/modules/profile/components/ProfileHeader/components/EditTradingPreferencesModal.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import type { TradingPreferences } from '@/types/trading';
+import { PreferencesStep } from '@/pages/welcome/components/steps/PreferencesStep';
+import { RiskStep } from '@/pages/welcome/components/steps/RiskStep';
+import Modal from '@/components/modal/Modal';
+import { useAuth } from '@/context/AuthContext';
+
+interface EditTradingPreferencesModalProps {
+  preferences: TradingPreferences;
+  onSave: (preferences: TradingPreferences) => void;
+  onClose: () => void;
+}
+
+const EditTradingPreferencesModal: React.FC<EditTradingPreferencesModalProps> = ({
+  preferences,
+  onSave,
+  onClose,
+}) => {
+  const { user } = useAuth();
+  const [currentStep, setCurrentStep] = React.useState<'preferences' | 'risk'>('preferences');
+  const [updatedPreferences, setUpdatedPreferences] = React.useState(preferences);
+
+  const handlePreferenceChange = (
+    field: keyof TradingPreferences,
+    value: TradingPreferences[keyof TradingPreferences]
+  ) => {
+    setUpdatedPreferences(prev => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSavePreferences = async () => {
+    try {
+      // Save preferences to backend
+      await fetch(`${import.meta.env.VITE_JSON_SERVER_URL}/users/${user?.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          tradingPreferences: updatedPreferences,
+        }),
+      });
+
+      // Update local storage
+      const authData = localStorage.getItem('auth');
+      if (authData) {
+        const parsed = JSON.parse(authData);
+        parsed.user.tradingPreferences = updatedPreferences;
+        localStorage.setItem('auth', JSON.stringify(parsed));
+      }
+
+      // Call the onSave callback
+      onSave(updatedPreferences);
+    } catch (error) {
+      console.error('Error updating trading preferences:', error);
+    }
+  };
+
+  const handleNext = async () => {
+    if (currentStep === 'preferences') {
+      setCurrentStep('risk');
+    } else {
+      await handleSavePreferences();
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      title={`Edit ${currentStep === 'preferences' ? 'Trading Preferences' : 'Risk Settings'}`}
+    >
+      {currentStep === 'preferences' ? (
+        <PreferencesStep
+          preferences={updatedPreferences}
+          handlePreferenceChange={handlePreferenceChange}
+          onNext={handleNext}
+        />
+      ) : (
+        <RiskStep
+          preferences={updatedPreferences}
+          handlePreferenceChange={handlePreferenceChange}
+          onNext={handleNext}
+          buttonText="Save"
+        />
+      )}
+    </Modal>
+  );
+};
+
+export default EditTradingPreferencesModal;

--- a/src/modules/profile/components/ProfileHeader/components/ProfileActions/ProfileActions.tsx
+++ b/src/modules/profile/components/ProfileHeader/components/ProfileActions/ProfileActions.tsx
@@ -1,38 +1,53 @@
-import Button from "@/components/input/Button";
-import "./ProfileActions.css";
+import Button from '@/components/input/Button';
+import { upgradeToLeader } from '@/services/userService';
+import './ProfileActions.css';
 
 interface ProfileActionsProps {
-    isOwnProfile: boolean;
-    isFollowing: boolean;
-    userType: string;
-    onFollow: () => Promise<void>;
-    onUnfollow: () => Promise<void>;
+  isOwnProfile: boolean;
+  isFollowing: boolean;
+  userType: string;
+  userId: string;
+  onFollow: () => Promise<void>;
+  onUnfollow: () => Promise<void>;
+  onUpgrade?: () => void;
 }
 
 const ProfileActions = ({
-    isOwnProfile,
-    isFollowing,
-    userType,
-    onFollow,
-    onUnfollow
+  isOwnProfile,
+  isFollowing,
+  userType,
+  userId,
+  onFollow,
+  onUnfollow,
+  onUpgrade,
 }: ProfileActionsProps) => {
-    return (
-        <div className="profile-actions">
-            {!isOwnProfile && (
-                <Button
-                    onClick={isFollowing ? onUnfollow : onFollow}
-                    variant={isFollowing ? "secondary" : "primary"}
-                >
-                    {isFollowing ? "Unfollow" : "Follow"}
-                </Button>
-            )}
-            {isOwnProfile && userType === "copier" && (
-                <Button variant="secondary">
-                    Upgrade to Leader
-                </Button>
-            )}
-        </div>
-    );
+  const handleUpgrade = async () => {
+    try {
+      await upgradeToLeader(userId);
+      onUpgrade?.();
+    } catch (error) {
+      console.error('Error upgrading to leader:', error);
+      // Here you might want to show an error notification to the user
+    }
+  };
+
+  return (
+    <div className="profile-actions">
+      {!isOwnProfile && (
+        <Button
+          onClick={isFollowing ? onUnfollow : onFollow}
+          variant={isFollowing ? 'secondary' : 'primary'}
+        >
+          {isFollowing ? 'Unfollow' : 'Follow'}
+        </Button>
+      )}
+      {isOwnProfile && userType === 'copier' && (
+        <Button variant="secondary" onClick={handleUpgrade}>
+          Upgrade to Leader
+        </Button>
+      )}
+    </div>
+  );
 };
 
 export default ProfileActions;

--- a/src/modules/profile/components/ProfileHeader/components/ProfileBasicInfo/ProfileBasicInfo.tsx
+++ b/src/modules/profile/components/ProfileHeader/components/ProfileBasicInfo/ProfileBasicInfo.tsx
@@ -1,56 +1,59 @@
-import "./ProfileBasicInfo.css";
-
-import ProfileBadge from "../ProfileBadge";
-import ProfileActions from "../ProfileActions";
+import './ProfileBasicInfo.css';
+import ProfileBadge from '../ProfileBadge';
+import ProfileActions from '../ProfileActions';
 
 interface ProfileBasicInfoProps {
-    username: string;
-    displayName?: string;
-    profilePicture?: string;
-    userType: string;
-    isOwnProfile: boolean;
-    isFollowing: boolean;
-    onFollow: () => Promise<void>;
-    onUnfollow: () => Promise<void>;
+  username: string;
+  displayName?: string;
+  profilePicture?: string;
+  userType: string;
+  userId: string;
+  isOwnProfile: boolean;
+  isFollowing: boolean;
+  onFollow: () => Promise<void>;
+  onUnfollow: () => Promise<void>;
+  onUpgrade?: () => void;
 }
 
 const ProfileBasicInfo = ({
-    username,
-    displayName,
-    profilePicture,
-    userType,
-    isOwnProfile,
-    isFollowing,
-    onFollow,
-    onUnfollow
+  username,
+  displayName,
+  profilePicture,
+  userType,
+  userId,
+  isOwnProfile,
+  isFollowing,
+  onFollow,
+  onUnfollow,
+  onUpgrade,
 }: ProfileBasicInfoProps) => {
-    const formattedDisplayName = displayName?.split('|')[0].trim() || username;
+  const formattedDisplayName = displayName?.split('|')[0].trim() || username;
 
-    return (
-        <div className="profile-basic-info">
-            <img
-                src={profilePicture || "/default-avatar.png"}
-                alt={username}
-                className="profile-basic-info__avatar"
-            />
-            <div className="profile-basic-info__content">
-                <div className="profile-basic-info__name-container">
-                    <h1 className="profile-basic-info__display-name">
-                        {formattedDisplayName}
-                    </h1>
-                    <ProfileBadge userType={userType} />
-                </div>
-                <span className="profile-basic-info__username">@{username}</span>
-                <ProfileActions
-                    isOwnProfile={isOwnProfile}
-                    isFollowing={isFollowing}
-                    userType={userType}
-                    onFollow={onFollow}
-                    onUnfollow={onUnfollow}
-                />
-            </div>
+  return (
+    <div className="profile-basic-info">
+      <img
+        src={profilePicture || '/default-avatar.png'}
+        alt={username}
+        className="profile-basic-info__avatar"
+      />
+      <div className="profile-basic-info__content">
+        <div className="profile-basic-info__name-container">
+          <h1 className="profile-basic-info__display-name">{formattedDisplayName}</h1>
+          <ProfileBadge userType={userType} />
         </div>
-    );
+        <span className="profile-basic-info__username">@{username}</span>
+        <ProfileActions
+          isOwnProfile={isOwnProfile}
+          isFollowing={isFollowing}
+          onFollow={onFollow}
+          onUnfollow={onUnfollow}
+          onUpgrade={onUpgrade}
+          userType={userType}
+          userId={userId}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default ProfileBasicInfo;

--- a/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.css
+++ b/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.css
@@ -1,0 +1,41 @@
+.profile-trading-preferences {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    gap: 1.5rem;
+    padding: 1.5rem;
+    background-color: #00d0ff10;
+    border-radius: 1rem;
+    width: 100%;
+    max-width: 400px;
+    margin-top: 1.5rem;
+}
+
+.profile-trading-preferences__stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.profile-trading-preferences__label {
+    font-size: 0.75rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.profile-trading-preferences__value {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #1f2937;
+    text-transform: capitalize;
+}
+
+@media (max-width: 640px) {
+    .profile-trading-preferences {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+        padding: 1rem;
+        max-width: 100%;
+    }
+}

--- a/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.css
+++ b/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.css
@@ -1,14 +1,48 @@
 .profile-trading-preferences {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(4, 1fr);
-    gap: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
     padding: 1.5rem;
     background-color: #00d0ff10;
     border-radius: 1rem;
     width: 100%;
     max-width: 400px;
     margin-top: 1.5rem;
+}
+
+.profile-trading-preferences__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.profile-trading-preferences__header h3 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0;
+}
+
+.profile-trading-preferences__edit-button {
+    background: none;
+    border: none;
+    padding: 0.5rem;
+    cursor: pointer;
+    color: #6b7280;
+    transition: color 0.2s;
+    border-radius: 0.375rem;
+}
+
+.profile-trading-preferences__edit-button:hover {
+    color: #1f2937;
+    background-color: #f3f4f6;
+}
+
+.profile-trading-preferences__stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
 }
 
 .profile-trading-preferences__stat {
@@ -33,9 +67,11 @@
 
 @media (max-width: 640px) {
     .profile-trading-preferences {
-        grid-template-columns: repeat(2, 1fr);
-        gap: 1rem;
-        padding: 1rem;
         max-width: 100%;
+        padding: 1rem;
+    }
+
+    .profile-trading-preferences__stats {
+        gap: 1rem;
     }
 }

--- a/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.tsx
+++ b/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { TradingPreferences } from '@/types/trading';
+import './ProfileTradingPreferences.css';
+
+interface ProfileTradingPreferencesProps {
+  preferences: TradingPreferences;
+}
+
+interface StatItemProps {
+  label: string;
+  value: string | number;
+  formatter?: (value: number) => string;
+}
+
+const StatItem: React.FC<StatItemProps> = ({ label, value, formatter }) => (
+  <div className="profile-trading-preferences__stat">
+    <span className="profile-trading-preferences__label">{label}</span>
+    <span className="profile-trading-preferences__value">
+      {formatter ? formatter(value as number) : value}
+    </span>
+  </div>
+);
+
+const formatCurrency = (value: number): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+};
+
+const formatPercentage = (value: number): string => `${value}%`;
+
+const ProfileTradingPreferences: React.FC<ProfileTradingPreferencesProps> = ({ preferences }) => {
+  const stats: StatItemProps[] = [
+    { label: 'Risk Tolerance', value: preferences.riskTolerance },
+    { label: 'Investment Style', value: preferences.investmentStyle },
+    { label: 'Trading Frequency', value: preferences.tradingFrequency },
+    { label: 'Max Drawdown', value: preferences.maxDrawdown, formatter: formatPercentage },
+    { label: 'Target Return', value: preferences.targetReturn, formatter: formatPercentage },
+    { label: 'Min Stake', value: preferences.minStake, formatter: formatCurrency },
+    { label: 'Max Stake', value: preferences.maxStake, formatter: formatCurrency },
+  ];
+
+  return (
+    <div className="profile-trading-preferences">
+      {stats.map(stat => (
+        <StatItem
+          key={stat.label}
+          label={stat.label}
+          value={stat.value}
+          formatter={stat.formatter}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ProfileTradingPreferences;

--- a/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.tsx
+++ b/src/modules/profile/components/ProfileHeader/components/ProfileTradingPreferences.tsx
@@ -1,9 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { TradingPreferences } from '@/types/trading';
+import EditTradingPreferencesModal from './EditTradingPreferencesModal';
+import EditIcon from '@/assets/icons/EditIcon';
 import './ProfileTradingPreferences.css';
 
 interface ProfileTradingPreferencesProps {
   preferences: TradingPreferences;
+  isOwnProfile?: boolean;
+  onUpdate?: (preferences: TradingPreferences) => void;
 }
 
 interface StatItemProps {
@@ -32,7 +36,12 @@ const formatCurrency = (value: number): string => {
 
 const formatPercentage = (value: number): string => `${value}%`;
 
-const ProfileTradingPreferences: React.FC<ProfileTradingPreferencesProps> = ({ preferences }) => {
+const ProfileTradingPreferences: React.FC<ProfileTradingPreferencesProps> = ({
+  preferences,
+  isOwnProfile = false,
+  onUpdate,
+}) => {
+  const [showEditModal, setShowEditModal] = useState(false);
   const stats: StatItemProps[] = [
     { label: 'Risk Tolerance', value: preferences.riskTolerance },
     { label: 'Investment Style', value: preferences.investmentStyle },
@@ -41,18 +50,55 @@ const ProfileTradingPreferences: React.FC<ProfileTradingPreferencesProps> = ({ p
     { label: 'Target Return', value: preferences.targetReturn, formatter: formatPercentage },
     { label: 'Min Stake', value: preferences.minStake, formatter: formatCurrency },
     { label: 'Max Stake', value: preferences.maxStake, formatter: formatCurrency },
+    {
+      label: 'Preferred Markets',
+      value:
+        preferences.preferredMarkets.length > 0 ? preferences.preferredMarkets.join(', ') : '-',
+    },
+    {
+      label: 'Preferred Trade Types',
+      value:
+        preferences.preferredTradeTypes.length > 0
+          ? preferences.preferredTradeTypes.join(', ')
+          : '-',
+    },
   ];
 
   return (
     <div className="profile-trading-preferences">
-      {stats.map(stat => (
-        <StatItem
-          key={stat.label}
-          label={stat.label}
-          value={stat.value}
-          formatter={stat.formatter}
+      <div className="profile-trading-preferences__header">
+        <h3>Trading Preferences</h3>
+        {isOwnProfile && (
+          <button
+            className="profile-trading-preferences__edit-button"
+            onClick={() => setShowEditModal(true)}
+            aria-label="Edit trading preferences"
+          >
+            <EditIcon />
+          </button>
+        )}
+      </div>
+      <div className="profile-trading-preferences__stats">
+        {stats.map(stat => (
+          <StatItem
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+            formatter={stat.formatter}
+          />
+        ))}
+      </div>
+
+      {showEditModal && (
+        <EditTradingPreferencesModal
+          preferences={preferences}
+          onSave={newPreferences => {
+            onUpdate?.(newPreferences);
+            setShowEditModal(false);
+          }}
+          onClose={() => setShowEditModal(false)}
         />
-      ))}
+      )}
     </div>
   );
 };

--- a/src/modules/profile/hooks/useProfile.ts
+++ b/src/modules/profile/hooks/useProfile.ts
@@ -1,86 +1,99 @@
-import { useState, useEffect } from "react";
-import type User from "@/types/user.types";
-import type Post from "@/types/post.types";
-import { getUserByUsername, getUserPosts, followUser, unfollowUser } from "../services/profileService";
-import { useAuth } from "@/context/AuthContext";
+import { useState, useEffect } from 'react';
+import type User from '@/types/user.types';
+import type Post from '@/types/post.types';
+import {
+  getUserByUsername,
+  getUserPosts,
+  followUser,
+  unfollowUser,
+} from '../services/profileService';
+import { useAuth } from '@/context/AuthContext';
 
 interface UseProfileResult {
-    profile: User | null;
-    posts: Post[];
-    isOwnProfile: boolean;
-    isFollowing: boolean;
-    loading: boolean;
-    error: string | null;
-    handleFollow: () => Promise<void>;
-    handleUnfollow: () => Promise<void>;
-    refetch: () => Promise<void>;
+  profile: User | null;
+  posts: Post[];
+  isOwnProfile: boolean;
+  isFollowing: boolean;
+  loading: boolean;
+  error: string | null;
+  handleFollow: () => Promise<void>;
+  handleUnfollow: () => Promise<void>;
+  handleProfileUpdate: (updatedProfile: User) => void;
+  refetch: () => Promise<void>;
 }
 
 export const useProfile = (username: string): UseProfileResult => {
-    const { user: currentUser } = useAuth();
-    const [profile, setProfile] = useState<User | null>(null);
-    const [posts, setPosts] = useState<Post[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+  const { user: currentUser, updateUser } = useAuth();
+  const [profile, setProfile] = useState<User | null>(null);
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-    const isOwnProfile = profile?.id === currentUser?.id;
-    const isFollowing = currentUser?.following?.includes(profile?.id || "") ?? false;
+  const isOwnProfile = profile?.id === currentUser?.id;
+  const isFollowing = currentUser?.following?.includes(profile?.id || '') ?? false;
 
-    const fetchProfile = async () => {
-        try {
-            setLoading(true);
-            setError(null);
-            const profileData = await getUserByUsername(username);
-            setProfile(profileData);
+  const fetchProfile = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const profileData = await getUserByUsername(username);
+      setProfile(profileData);
 
-            const userPosts = await getUserPosts(profileData.id);
-            setPosts(userPosts);
-        } catch (err) {
-            setError(err instanceof Error ? err.message : "An error occurred");
-            setProfile(null);
-            setPosts([]);
-        } finally {
-            setLoading(false);
-        }
-    };
+      const userPosts = await getUserPosts(profileData.id);
+      setPosts(userPosts);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+      setProfile(null);
+      setPosts([]);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    useEffect(() => {
-        if (username) {
-            fetchProfile();
-        }
-    }, [username]);
+  useEffect(() => {
+    if (username) {
+      fetchProfile();
+    }
+  }, [username]);
 
-    const handleFollow = async () => {
-        if (!currentUser || !profile) return;
-        try {
-            setError(null);
-            await followUser(currentUser.id, profile.id);
-            await fetchProfile();
-        } catch (err) {
-            setError(err instanceof Error ? err.message : "Failed to follow user");
-        }
-    };
+  const handleFollow = async () => {
+    if (!profile || !currentUser) return;
+    try {
+      await followUser(profile.id, currentUser.id);
+      fetchProfile();
+    } catch (err) {
+      console.error('Error following user:', err);
+    }
+  };
 
-    const handleUnfollow = async () => {
-        if (!currentUser || !profile) return;
-        try {
-            setError(null);
-            await unfollowUser(currentUser.id, profile.id);
-            await fetchProfile();
-        } catch (err) {
-            setError(err instanceof Error ? err.message : "Failed to unfollow user");
-        }
-    };
+  const handleUnfollow = async () => {
+    if (!profile || !currentUser) return;
+    try {
+      await unfollowUser(profile.id, currentUser.id);
+      fetchProfile();
+    } catch (err) {
+      console.error('Error unfollowing user:', err);
+    }
+  };
 
-    return {
-        profile,
-        posts,
-        isOwnProfile,
-        isFollowing,
-        loading,
-        error,
-        handleFollow,
-        handleUnfollow,
-        refetch: fetchProfile
-    };
+  const handleProfileUpdate = (updatedProfile: User) => {
+    setProfile(updatedProfile);
+    if (isOwnProfile && updateUser) {
+      updateUser(updatedProfile);
+    }
+    fetchProfile(); // Refresh the profile data
+  };
+
+  return {
+    profile,
+    posts,
+    isOwnProfile,
+    isFollowing,
+    loading,
+    error,
+    handleFollow,
+    handleUnfollow,
+    handleProfileUpdate,
+    refetch: fetchProfile,
+  };
 };

--- a/src/modules/profile/hooks/useProfile.ts
+++ b/src/modules/profile/hooks/useProfile.ts
@@ -78,10 +78,13 @@ export const useProfile = (username: string): UseProfileResult => {
 
   const handleProfileUpdate = (updatedProfile: User) => {
     setProfile(updatedProfile);
-    if (isOwnProfile && updateUser) {
-      updateUser(updatedProfile);
+    if (isOwnProfile) {
+      if (updateUser) {
+        updateUser(updatedProfile);
+        return; // Skip redundant fetching since updateUser updates the UI state
+      }
     }
-    fetchProfile(); // Refresh the profile data
+    fetchProfile(); // Refresh the profile data if updateUser isn't provided or it's not an own profile update
   };
 
   return {

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -16,6 +16,7 @@ const Profile = () => {
     error,
     handleFollow,
     handleUnfollow,
+    handleProfileUpdate,
     refetch,
   } = useProfile(username);
 
@@ -45,6 +46,7 @@ const Profile = () => {
         isFollowing={isFollowing}
         onFollow={handleFollow}
         onUnfollow={handleUnfollow}
+        onProfileUpdate={handleProfileUpdate}
       />
       <div className="profile-page__content">
         <div className="profile-page__feed">

--- a/src/pages/welcome/components/steps/RiskStep.tsx
+++ b/src/pages/welcome/components/steps/RiskStep.tsx
@@ -1,30 +1,30 @@
-import React from "react";
-import { TradingPreferences } from "../../../../types/trading";
-import { RangeField } from "../form/RangeField";
-import { NumberField } from "../form/NumberField";
-import { HelperBox } from "../form/HelperBox";
-
-type TRiskTolerance = TradingPreferences[keyof TradingPreferences];
+import React from 'react';
+import { TradingPreferences } from '../../../../types/trading';
+import { RangeField } from '../form/RangeField';
+import { NumberField } from '../form/NumberField';
+import { HelperBox } from '../form/HelperBox';
 
 interface RiskStepProps {
   preferences: TradingPreferences;
   handlePreferenceChange: (
     field: keyof TradingPreferences,
-    value: TRiskTolerance
+    value: TradingPreferences[keyof TradingPreferences]
   ) => void;
   onNext: () => void;
+  buttonText?: string;
 }
 
 export const RiskStep: React.FC<RiskStepProps> = ({
   preferences,
   handlePreferenceChange,
   onNext,
+  buttonText = 'Get Started',
 }) => {
   const isStakeError = preferences.minStake > preferences.maxStake;
 
   return (
     <div className="step-content risk-step">
-      <form className="preferences-form" onSubmit={(e) => e.preventDefault()}>
+      <form className="preferences-form" onSubmit={e => e.preventDefault()}>
         <RangeField
           label="Maximum Drawdown (%)"
           helperText="Maximum loss you're willing to accept"
@@ -32,7 +32,7 @@ export const RiskStep: React.FC<RiskStepProps> = ({
           min={5}
           max={50}
           step={5}
-          onChange={(value) => handlePreferenceChange("maxDrawdown", value)}
+          onChange={value => handlePreferenceChange('maxDrawdown', value)}
         />
 
         <RangeField
@@ -42,7 +42,7 @@ export const RiskStep: React.FC<RiskStepProps> = ({
           min={5}
           max={100}
           step={5}
-          onChange={(value) => handlePreferenceChange("targetReturn", value)}
+          onChange={value => handlePreferenceChange('targetReturn', value)}
         />
 
         <NumberField
@@ -50,8 +50,8 @@ export const RiskStep: React.FC<RiskStepProps> = ({
           helperText="Minimum amount to invest per trade"
           value={preferences.minStake}
           min={1}
-          onChange={(value) => handlePreferenceChange("minStake", value)}
-          error={isStakeError ? "Minimum stake cannot be greater than maximum stake" : undefined}
+          onChange={value => handlePreferenceChange('minStake', value)}
+          error={isStakeError ? 'Minimum stake cannot be greater than maximum stake' : undefined}
           className="stake-input"
         />
 
@@ -60,25 +60,20 @@ export const RiskStep: React.FC<RiskStepProps> = ({
           helperText="Maximum amount to invest per trade"
           value={preferences.maxStake}
           min={preferences.minStake}
-          onChange={(value) => handlePreferenceChange("maxStake", value)}
-          error={isStakeError ? "Maximum stake cannot be less than minimum stake" : undefined}
+          onChange={value => handlePreferenceChange('maxStake', value)}
+          error={isStakeError ? 'Maximum stake cannot be less than minimum stake' : undefined}
           className="stake-input"
         />
 
         <HelperBox>
           <p>
-            These settings help us ensure your trading activity aligns with your
-            risk tolerance and investment goals.
+            These settings help us ensure your trading activity aligns with your risk tolerance and
+            investment goals.
           </p>
         </HelperBox>
 
-        <button
-          type="button"
-          className="next-step-button"
-          onClick={onNext}
-          disabled={isStakeError}
-        >
-          Get Started
+        <button type="button" className="next-step-button" onClick={onNext} disabled={isStakeError}>
+          {buttonText}
         </button>
       </form>
     </div>

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,4 @@
-import { UserType } from "../types/user";
+import { UserType } from '../types/user';
 
 interface RawUser {
   id: string;
@@ -7,6 +7,17 @@ interface RawUser {
   displayName?: string;
   userType?: UserType;
   isFirstLogin?: boolean;
+  tradingPreferences?: {
+    riskTolerance: string;
+    investmentStyle: string;
+    preferredMarkets: string[];
+    preferredTradeTypes: string[];
+    tradingFrequency: string;
+    maxDrawdown: number;
+    targetReturn: number;
+    minStake: number;
+    maxStake: number;
+  };
 }
 
 interface LoginCredentials {
@@ -22,6 +33,17 @@ interface AuthResponse {
     displayName: string;
     userType: UserType;
     isFirstLogin?: boolean;
+    tradingPreferences?: {
+      riskTolerance: string;
+      investmentStyle: string;
+      preferredMarkets: string[];
+      preferredTradeTypes: string[];
+      tradingFrequency: string;
+      maxDrawdown: number;
+      targetReturn: number;
+      minStake: number;
+      maxStake: number;
+    };
   };
   token: string;
 }
@@ -29,26 +51,22 @@ interface AuthResponse {
 class AuthError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "AuthError";
+    this.name = 'AuthError';
   }
 }
 
-export const login = async (
-  credentials: LoginCredentials
-): Promise<AuthResponse> => {
+export const login = async (credentials: LoginCredentials): Promise<AuthResponse> => {
   try {
     const response = await fetch(`${import.meta.env.VITE_JSON_SERVER_URL}/users`);
     const users = await response.json();
 
     // Mock authentication - in real app this would be a proper API call
     const user = users.find(
-      (u: RawUser) =>
-        u.username === credentials.username &&
-        credentials.password === "password"
+      (u: RawUser) => u.username === credentials.username && credentials.password === 'password'
     );
 
     if (!user) {
-      throw new AuthError("Invalid username or password");
+      throw new AuthError('Invalid username or password');
     }
 
     // Ensure user has required properties
@@ -57,32 +75,41 @@ export const login = async (
       userType: user.userType || UserType.COPIER, // Default to copier if not set
       isFirstLogin: user.isFirstLogin ?? true, // Default to true if not set
       displayName: user.displayName || user.username, // Default to username if displayName not set
+      tradingPreferences: user.tradingPreferences || {
+        riskTolerance: 'medium',
+        investmentStyle: 'moderate',
+        preferredMarkets: [],
+        preferredTradeTypes: [],
+        tradingFrequency: 'weekly',
+        maxDrawdown: 20,
+        targetReturn: 15,
+        minStake: 10,
+        maxStake: 100,
+      },
     };
 
     // Mock token generation
-    const token = btoa(
-      JSON.stringify({ userId: userWithDefaults.id, timestamp: Date.now() })
-    );
+    const token = btoa(JSON.stringify({ userId: userWithDefaults.id, timestamp: Date.now() }));
 
     // Store auth data
     const authData = { user: userWithDefaults, token };
-    localStorage.setItem("auth", JSON.stringify(authData));
+    localStorage.setItem('auth', JSON.stringify(authData));
 
     return authData;
   } catch (error) {
     if (error instanceof AuthError) {
       throw error;
     }
-    throw new Error("Authentication failed. Please try again later.");
+    throw new Error('Authentication failed. Please try again later.');
   }
 };
 
 export const logout = (): void => {
-  localStorage.removeItem("auth");
+  localStorage.removeItem('auth');
 };
 
 export const getStoredAuth = (): AuthResponse | null => {
-  const authData = localStorage.getItem("auth");
+  const authData = localStorage.getItem('auth');
   return authData ? JSON.parse(authData) : null;
 };
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -8,8 +8,8 @@ interface RawUser {
   userType?: UserType;
   isFirstLogin?: boolean;
   tradingPreferences?: {
-    riskTolerance: string;
-    investmentStyle: string;
+    riskTolerance: 'medium' | 'low' | 'high';
+    investmentStyle: 'moderate' | 'conservative' | 'aggressive';
     preferredMarkets: string[];
     preferredTradeTypes: string[];
     tradingFrequency: string;
@@ -34,11 +34,11 @@ interface AuthResponse {
     userType: UserType;
     isFirstLogin?: boolean;
     tradingPreferences?: {
-      riskTolerance: string;
-      investmentStyle: string;
+      riskTolerance: 'medium' | 'low' | 'high';
+      investmentStyle: 'moderate' | 'conservative' | 'aggressive';
       preferredMarkets: string[];
       preferredTradeTypes: string[];
-      tradingFrequency: string;
+      tradingFrequency: 'weekly' | 'monthly' | 'daily';
       maxDrawdown: number;
       targetReturn: number;
       minStake: number;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -85,3 +85,45 @@ export async function getUserRelationship(
     throw error;
   }
 }
+
+export async function upgradeToLeader(userId: string): Promise<void> {
+  try {
+    // Get user data
+    const response = await fetch(`${JSON_SERVER_URL}/users/${userId}`);
+    const user = await response.json();
+
+    // Update user type and add leader-specific fields
+    const updatedUser = {
+      ...user,
+      userType: 'leader',
+      performance: {
+        winRate: 0,
+        totalPnL: 0,
+        monthlyReturn: 0,
+        totalTrades: 0,
+      },
+      // Keep existing trading preferences or set defaults if none exist
+      tradingPreferences: user.tradingPreferences || {
+        riskTolerance: 'medium',
+        investmentStyle: 'moderate',
+        preferredMarkets: [],
+        preferredTradeTypes: [],
+        tradingFrequency: 'weekly',
+        maxDrawdown: 20,
+        targetReturn: 15,
+        minStake: 10,
+        maxStake: 100,
+      },
+    };
+
+    // Update user in database
+    await fetch(`${JSON_SERVER_URL}/users/${userId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updatedUser),
+    });
+  } catch (error) {
+    console.error('Error upgrading user to leader:', error);
+    throw new Error('Failed to upgrade user to leader');
+  }
+}

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -1,4 +1,5 @@
 import type Strategy from './strategy.types';
+import type { TradingPreferences } from './trading';
 
 export enum UserType {
   LEADER = 'leader',
@@ -25,6 +26,7 @@ interface User {
   createdAt?: string;
   updatedAt?: string;
   isFirstLogin?: boolean;
+  tradingPreferences?: TradingPreferences;
 }
 
 export default User;


### PR DESCRIPTION
- Functionality of upgrading to the leader
- Add trading preferences to the profile (for both leader and copiers). There are default values, but they can be changed by editing directly from profile page or if copier on first log in set them up

## Summary by Sourcery

This pull request introduces the functionality for users to upgrade to a leader profile and adds trading preferences to user profiles. It includes UI enhancements for displaying and editing these preferences.

New Features:
- Adds the ability for users to upgrade their profile to a leader profile.
- Introduces trading preferences to user profiles, allowing both leaders and copiers to customize their trading settings.

Enhancements:
- Improves the profile page by adding a section to display and edit trading preferences.
- Enhances the user interface with a modal for editing trading preferences, including risk settings.