### PR TITLE
fix assets for leaders

### DIFF
--- a/src/components/AILoader/AILoader.tsx
+++ b/src/components/AILoader/AILoader.tsx
@@ -37,7 +37,7 @@ const AILoader: React.FC<AILoaderProps> = ({
           className="ai-loader__svg"
         />
       </div>
-      {showText && <div className="ai-loader__text">Analyzing with AI...</div>}
+      {showText && <div className="ai-loader__text">{title ?? 'Analyzing with AI...'}</div>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary by Sourcery

This pull request fixes an issue where the Discover page was not correctly displaying the tabs for leaders. It ensures that the tabs are only rendered after the `isLeader` state has been determined, preventing a brief flash of incorrect tabs. It also refactors the logic for determining if a user is a leader into a separate useEffect hook.