### PR TITLE
styles: move close button to left for Overlay

### DIFF
--- a/src/components/Overlay/Overlay.css
+++ b/src/components/Overlay/Overlay.css
@@ -27,15 +27,11 @@
     width: 100%;
     display: flex;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: space-between;
 }
 
 .overlay__header > svg {
   stroke: var(--text-primary);
-}
-
-.overlay__header-content {
-  margin-right: auto;
 }
 
 .overlay__content {

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -55,10 +55,10 @@ const Overlay = ({
   return (
     <div className={`overlay ${animationState} ${className}`} onClick={handleBackdropClick}>
       <div className="overlay__header">
-        <div className="overlay__header-content">{header}</div>
         <button className="overlay__close" onClick={onClose}>
           <CloseIcon />
         </button>
+        <div className="overlay__header-content">{header}</div>
       </div>
       <div className="overlay__content" onAnimationEnd={handleAnimationEnd}>
         {children}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Moved the close button in the Overlay component to the left side of the header.