### PR TITLE
fix stop propogation

### DIFF
--- a/src/components/strategy/StrategyListItem/StrategyListItem.tsx
+++ b/src/components/strategy/StrategyListItem/StrategyListItem.tsx
@@ -45,7 +45,6 @@ const StrategyListItem: FC<StrategyListItemProps> = ({
       (e.target as HTMLElement).closest('button')
     ) {
       e.stopPropagation();
-      e.preventDefault();
       return;
     }
     if (selected) {

--- a/src/components/strategy/StrategyListItem/StrategyListItem.tsx
+++ b/src/components/strategy/StrategyListItem/StrategyListItem.tsx
@@ -39,7 +39,15 @@ const StrategyListItem: FC<StrategyListItemProps> = ({
     return `strategy-list__risk strategy-list__risk--${level}`;
   };
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
+    if (
+      (e.target as HTMLElement).tagName === 'BUTTON' ||
+      (e.target as HTMLElement).closest('button')
+    ) {
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
     if (selected) {
       onSelect?.();
     } else {

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -3,8 +3,8 @@ import { useCallback, useRef } from 'react';
 type Timer = ReturnType<typeof setTimeout>;
 
 interface UseLongPressOptions {
-  onClick?: (event: EventType) => void;
-  onLongPress?: (event: EventType) => void;
+  onClick?: (event: any) => void;
+  onLongPress?: (event: any) => void;
   ms?: number;
 }
 
@@ -16,7 +16,9 @@ export const useLongPress = ({ onClick, onLongPress, ms = 300 }: UseLongPressOpt
 
   const start = useCallback(
     (event: EventType): void => {
-      event.preventDefault();
+      if (event.type === 'mousedown') {
+        event.preventDefault();
+      }
       isLongPress.current = false;
       timerRef.current = setTimeout(() => {
         isLongPress.current = true;
@@ -28,7 +30,9 @@ export const useLongPress = ({ onClick, onLongPress, ms = 300 }: UseLongPressOpt
 
   const stop = useCallback(
     (event: EventType, shouldTriggerClick: boolean = true): void => {
-      event.preventDefault();
+      if (event.type === 'mouseup' || event.type === 'mouseleave') {
+        event.preventDefault();
+      }
       if (timerRef.current) clearTimeout(timerRef.current);
       if (shouldTriggerClick && !isLongPress.current && onClick) {
         onClick(event);

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -3,8 +3,8 @@ import { useCallback, useRef } from 'react';
 type Timer = ReturnType<typeof setTimeout>;
 
 interface UseLongPressOptions {
-  onClick?: () => void;
-  onLongPress?: () => void;
+  onClick?: (event: EventType) => void;
+  onLongPress?: (event: EventType) => void;
   ms?: number;
 }
 
@@ -20,7 +20,7 @@ export const useLongPress = ({ onClick, onLongPress, ms = 300 }: UseLongPressOpt
       isLongPress.current = false;
       timerRef.current = setTimeout(() => {
         isLongPress.current = true;
-        onLongPress?.();
+        onLongPress?.(event);
       }, ms);
     },
     [onLongPress, ms]
@@ -31,7 +31,7 @@ export const useLongPress = ({ onClick, onLongPress, ms = 300 }: UseLongPressOpt
       event.preventDefault();
       if (timerRef.current) clearTimeout(timerRef.current);
       if (shouldTriggerClick && !isLongPress.current && onClick) {
-        onClick();
+        onClick(event);
       }
     },
     [onClick]


### PR DESCRIPTION
## Summary by Sourcery

Fix event propagation in StrategyListItem component and enhance useLongPress hook to include event objects in callback functions.

Bug Fixes:
- Fix event propagation issue in StrategyListItem component by stopping propagation and preventing default action when a button is clicked.

Enhancements:
- Update useLongPress hook to pass the event object to onClick and onLongPress callbacks, allowing for more detailed event handling.