### PR TITLE
Mayuran/strategies fix

### DIFF
--- a/src/modules/discover/services/discoverService.ts
+++ b/src/modules/discover/services/discoverService.ts
@@ -182,7 +182,7 @@ export const discoverService = {
           body: JSON.stringify(strategy),
         });
 
-        return false; // Not copying anymore
+        return true; // Not copying anymore
       } else {
         // Create new copy relationship
         const copyRelationship = {
@@ -215,7 +215,7 @@ export const discoverService = {
       }
     } catch (error) {
       console.error('Error copying strategy:', error);
-      throw error;
+      return false;
     }
   },
 


### PR DESCRIPTION
## Summary by Sourcery

Improves the strategy copying functionality by adding multi-select support and fixing issues with copy status updates. The changes include UI enhancements for strategy selection, a long press interaction for activating checkboxes, and fixes to ensure the copy status is correctly reflected across the application.

Bug Fixes:
- Fixes an issue where the copy status of strategies was not being correctly updated in the Discover section.
- Fixes an issue where strategies were not being unselected when the active filter changed.

Enhancements:
- Improves the strategy selection process by using a long press to activate checkboxes for multiple selections.
- Updates the UI to display the number of selected strategies when copying or stopping copying.
- Adds a cancel button to clear selected strategies.
- Improves the ProfileStats component to handle strategy selection and deselection, including UI updates and API calls.
- Adds a hook to handle long press events.